### PR TITLE
Fix searchFormat not working for `DateField` & `TimeField`

### DIFF
--- a/starlette_admin/statics/js/list.js
+++ b/starlette_admin/statics/js/list.js
@@ -3,7 +3,7 @@ $(function () {
   var dt_columns = [];
 
   (function () {
-    let fringe = [...model.fields];
+    let fringe = structuredClone(model.fields);
     while (fringe.length > 0) {
       let field = fringe.shift(0);
       if (field.type === "CollectionField")

--- a/starlette_admin/statics/js/list.js
+++ b/starlette_admin/statics/js/list.js
@@ -3,7 +3,7 @@ $(function () {
   var dt_columns = [];
 
   (function () {
-    let fringe = model.fields;
+    let fringe = [...model.fields];
     while (fringe.length > 0) {
       let field = fringe.shift(0);
       if (field.type === "CollectionField")

--- a/starlette_admin/statics/js/utils.js
+++ b/starlette_admin/statics/js/utils.js
@@ -52,3 +52,10 @@ function pretty_print_json(data) {
     .replace(/>/g, "&gt;")
     .replace(jsonLine, replacer);
 }
+
+if (typeof structuredClone === 'undefined') {
+  // Simple (non-performant) replacemente of `structuredClone` for old browsers
+  structuredClone = function (value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+}

--- a/starlette_admin/statics/js/utils.js
+++ b/starlette_admin/statics/js/utils.js
@@ -54,7 +54,7 @@ function pretty_print_json(data) {
 }
 
 if (typeof structuredClone === 'undefined') {
-  // Simple (non-performant) replacemente of `structuredClone` for old browsers
+  // Simple (non-performant) replacement of `structuredClone` for old browsers
   structuredClone = function (value) {
     return JSON.parse(JSON.stringify(value));
   }


### PR DESCRIPTION
Copy the `model.fields` list before apply the `shift` function to keep original values un the `model` object. Otherwise, other functions cannot find fields attributes. For example, the extraction of the `search_format` in https://github.com/jowilf/starlette-admin/blob/main/starlette_admin/statics/js/list.js#L164 does not work.