### PR TITLE
Fixed "Mixed content" error when using https

### DIFF
--- a/starlette_admin/templates/base.html
+++ b/starlette_admin/templates/base.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     {% block head_meta %}{% endblock %}
     {% block title %}<title>{{ title }}</title>{% endblock %}
     <link rel="stylesheet" href="{{ url_for(__name__ ~ ':statics', path='css/tabler.min.css') }}">


### PR DESCRIPTION
When using https, you get an error loading static files
`Mixed Content: The page at 'https://***/admin/' was loaded over HTTPS, but requested an insecure stylesheet 'http://***/admin/statics/css/tabler.min.css'. This request has been blocked; the content must be served over HTTPS.`
This PR fixes the problem