### PR TITLE
Fixed a regression caused by #361 where SQLAlchemy models with Mixin Classes raises AttributeError

### DIFF
--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+* Fixed a regression caused by [#361](https://github.com/jowilf/starlette-admin/pull/361) where SQLAlchemy models with
+  Mixin Classes raises AttributeError by [@hasansezertasan](https://github.com/hasansezertasan)
+  in [#383](https://github.com/jowilf/starlette-admin/pull/383)
+
 ## [0.12.0] - 2023-11-07
 
 ### Added
@@ -58,7 +62,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   name by [@jowilf](https://github.com/jowilf)
   in [#361](https://github.com/jowilf/starlette-admin/pull/361)
 
-* Fix a bug with field access authorization where restricted users could not modify a partial list of fields in an
+* Fixed a bug with field access authorization where restricted users could not modify a partial list of fields in an
   entity by [@jowilf](https://github.com/jowilf) in [#360](https://github.com/jowilf/starlette-admin/pull/360)
 
 ### Internals

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -9,7 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Fixed a regression caused by [#361](https://github.com/jowilf/starlette-admin/pull/361) where SQLAlchemy models with
   Mixin Classes raises AttributeError by [@hasansezertasan](https://github.com/hasansezertasan)
-  in [#383](https://github.com/jowilf/starlette-admin/pull/383)
+  in [#385](https://github.com/jowilf/starlette-admin/pull/385)
 
 ## [0.12.0] - 2023-11-07
 

--- a/starlette_admin/contrib/sqla/view.py
+++ b/starlette_admin/contrib/sqla/view.py
@@ -93,7 +93,7 @@ class ModelView(BaseModelView):
         )
         self.name = name or self.name or prettify_class_name(self.model.__name__)
         self.icon = icon
-        self._pk_column: Column = list(mapper.local_table.primary_key)[0]
+        self._pk_column: Column = next(iter(mapper.local_table.primary_key))
         self._setup_primary_key()
         self._pk_coerce = extract_column_python_type(self._pk_column)
         if self.fields is None or len(self.fields) == 0:
@@ -142,7 +142,6 @@ class ModelView(BaseModelView):
         raise InvalidModelError(
             f"Cannot find primary key attribute for model {self.model.__name__}"
         )
-
 
     async def handle_action(
         self, request: Request, pks: List[Any], name: str

--- a/starlette_admin/contrib/sqla/view.py
+++ b/starlette_admin/contrib/sqla/view.py
@@ -93,7 +93,7 @@ class ModelView(BaseModelView):
         )
         self.name = name or self.name or prettify_class_name(self.model.__name__)
         self.icon = icon
-        self._pk_column: Column = next(iter(mapper.local_table.primary_key))
+        self._pk_column: Column = next(iter(mapper.local_table.primary_key))  # type: ignore
         self._setup_primary_key()
         self._pk_coerce = extract_column_python_type(self._pk_column)
         if self.fields is None or len(self.fields) == 0:
@@ -133,7 +133,7 @@ class ModelView(BaseModelView):
     def _setup_primary_key(self) -> None:
         # Detect the primary key attribute of the model
         mapper: Mapper = inspect(self.model)  # type: ignore
-        for key, attr in mapper._props.items():
+        for key, attr in mapper._props.items():  # type: ignore
             if not hasattr(attr, "columns"):
                 continue
             if self._pk_column is attr.columns[0]:

--- a/starlette_admin/contrib/sqla/view.py
+++ b/starlette_admin/contrib/sqla/view.py
@@ -132,16 +132,13 @@ class ModelView(BaseModelView):
 
     def _setup_primary_key(self) -> None:
         # Detect the primary key attribute of the model
-        mapper: Mapper = inspect(self.model)  # type: ignore
-        for key, attr in mapper._props.items():  # type: ignore
-            if not hasattr(attr, "columns"):
-                continue
-            if self._pk_column is attr.columns[0]:
+        for key in self.model.__dict__:
+            attr = getattr(self.model, key)
+            if isinstance(attr, InstrumentedAttribute) and getattr(
+                attr, "primary_key", False
+            ):
                 self.pk_attr = key
                 return
-        raise InvalidModelError(
-            f"Cannot find primary key attribute for model {self.model.__name__}"
-        )
 
     async def handle_action(
         self, request: Request, pks: List[Any], name: str

--- a/tests/sqla/test_sqla_and_pydantic.py
+++ b/tests/sqla/test_sqla_and_pydantic.py
@@ -29,19 +29,21 @@ pytestmark = pytest.mark.asyncio
 Base = declarative_base()
 
 
-class User(Base):
+class IDMixin:
+    id = Column(Integer, primary_key=True)
+
+
+class User(Base, IDMixin):
     __tablename__ = "user"
 
-    id = Column(Integer, primary_key=True)
     name = Column(String(100))
 
     todos = relationship("Todo", back_populates="user")
 
 
-class Todo(Base):
+class Todo(Base, IDMixin):
     __tablename__ = "todo"
 
-    id = Column(Integer, primary_key=True)
     todo = Column(String(255))
     completed = Column(Boolean)
     deadline = Column(DateTime)


### PR DESCRIPTION
Fixes #383  and partially fixes #369

There is a module called `SQLAlchemy-Mixins`, `FastAP-Users` uses `mixins`, and most probably any project that has +3 models with same primary key structure uses mixins, so its quite popular. @jowilf I believe we should patch the version immediately because many SQLAlchemy users will be using custom or third party `mixins`.

