### PR TITLE
Fixed issue where "Empty" and "Not Empty" filters raised NotImplementedError on SQLAlchemy relationship attributes

### DIFF
--- a/starlette_admin/contrib/sqla/helpers.py
+++ b/starlette_admin/contrib/sqla/helpers.py
@@ -3,8 +3,28 @@ from typing import Any, Callable, Dict, Optional, Sequence
 from sqlalchemy import Column, String, and_, cast, false, not_, or_, true
 from sqlalchemy.orm import (
     InstrumentedAttribute,
+    RelationshipProperty,
 )
+from sqlalchemy.orm.attributes import ScalarObjectAttributeImpl
 from sqlalchemy.sql import ClauseElement
+
+
+
+def __is_null(latest_attr: InstrumentedAttribute) -> Any:
+    if isinstance(latest_attr.property, RelationshipProperty):
+        if isinstance(latest_attr.impl, ScalarObjectAttributeImpl):
+            return ~latest_attr.has()
+        return ~latest_attr.any()
+    return latest_attr.is_(None)
+
+
+def __is_not_null(latest_attr: InstrumentedAttribute) -> Any:
+    if isinstance(latest_attr.property, RelationshipProperty):
+        if isinstance(latest_attr.impl, ScalarObjectAttributeImpl):
+            return latest_attr.has()
+        return latest_attr.any()
+    return latest_attr.is_not(None)
+
 
 OPERATORS: Dict[str, Callable[[InstrumentedAttribute, Any], ClauseElement]] = {
     "eq": lambda f, v: f == v,
@@ -23,8 +43,8 @@ OPERATORS: Dict[str, Callable[[InstrumentedAttribute, Any], ClauseElement]] = {
     "not_contains": lambda f, v: not_(cast(f, String).contains(v)),
     "is_false": lambda f, v: f == false(),
     "is_true": lambda f, v: f == true(),
-    "is_null": lambda f, v: f.is_(None),
-    "is_not_null": lambda f, v: f.is_not(None),
+    "is_null": lambda f, v: __is_null(f),
+    "is_not_null": lambda f, v: __is_not_null(f),
     "between": lambda f, v: f.between(*v),
     "not_between": lambda f, v: not_(f.between(*v)),
 }

--- a/starlette_admin/contrib/sqla/helpers.py
+++ b/starlette_admin/contrib/sqla/helpers.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm.attributes import ScalarObjectAttributeImpl
 from sqlalchemy.sql import ClauseElement
 
 
-
 def __is_null(latest_attr: InstrumentedAttribute) -> Any:
     if isinstance(latest_attr.property, RelationshipProperty):
         if isinstance(latest_attr.impl, ScalarObjectAttributeImpl):

--- a/tests/sqla/test_sync_engine.py
+++ b/tests/sqla/test_sync_engine.py
@@ -248,30 +248,39 @@ async def test_api_query5(client: AsyncClient):
     data = response.json()
     assert data["total"] == 4
 
-@pytest.mark.parametrize('resource,where,total',
-                         [
-                             ('user',('{"and":[{"products": {"is_null": {}}}]}'),1),
-                             ('user',('{"and":[{"products": {"is_not_null": {}}}]}'),2),
-                             ('user',
-                              ('{"and":[{"products": {"is_not_null": {}}},{"name": {"eq": "Doe"}}]}'),
-                               1,
-                             ),
-                             ('user',
-                              ('{"or":[{"products": {"is_not_null": {}}},{"name": {"eq": "admin"}}]}'),
-                              3,
-                             ),
-                             ('product',('{"and":[{"user": {"is_not_null": {}}}]}'),2),
-                             ('product',('{"and":[{"user": {"is_null": {}}}]}'),3),
-                             ('product',
-                              ('{"and":[{"user": {"is_not_null": {}}},{"title": {"eq": "OPPOF19"}}]}'),
-                              1,
-                             ),
-                             ('product',
-                              ('{"or":[{"user": {"is_not_null": {}}},{"title": {"eq": "OPPOF19"}}]}'),
-                              2,
-                             ),
-                         ])
-async def test_api_query6(client: AsyncClient, resource: str, where: tuple[str], total: int):
+
+@pytest.mark.parametrize(
+    "resource,where,total",
+    [
+        ("user", ('{"and":[{"products": {"is_null": {}}}]}'), 1),
+        ("user", ('{"and":[{"products": {"is_not_null": {}}}]}'), 2),
+        (
+            "user",
+            ('{"and":[{"products": {"is_not_null": {}}},{"name": {"eq": "Doe"}}]}'),
+            1,
+        ),
+        (
+            "user",
+            ('{"or":[{"products": {"is_not_null": {}}},{"name": {"eq": "admin"}}]}'),
+            3,
+        ),
+        ("product", ('{"and":[{"user": {"is_not_null": {}}}]}'), 2),
+        ("product", ('{"and":[{"user": {"is_null": {}}}]}'), 3),
+        (
+            "product",
+            ('{"and":[{"user": {"is_not_null": {}}},{"title": {"eq": "OPPOF19"}}]}'),
+            1,
+        ),
+        (
+            "product",
+            ('{"or":[{"user": {"is_not_null": {}}},{"title": {"eq": "OPPOF19"}}]}'),
+            2,
+        ),
+    ],
+)
+async def test_api_query6(
+    client: AsyncClient, resource: str, where: tuple[str], total: int
+):
     response = await client.get(f"/admin/api/{resource}?where={where}")
     data = response.json()
     assert data["total"] == total

--- a/tests/sqla/test_sync_engine.py
+++ b/tests/sqla/test_sync_engine.py
@@ -248,6 +248,34 @@ async def test_api_query5(client: AsyncClient):
     data = response.json()
     assert data["total"] == 4
 
+@pytest.mark.parametrize('resource,where,total',
+                         [
+                             ('user',('{"and":[{"products": {"is_null": {}}}]}'),1),
+                             ('user',('{"and":[{"products": {"is_not_null": {}}}]}'),2),
+                             ('user',
+                              ('{"and":[{"products": {"is_not_null": {}}},{"name": {"eq": "Doe"}}]}'),
+                               1,
+                             ),
+                             ('user',
+                              ('{"or":[{"products": {"is_not_null": {}}},{"name": {"eq": "admin"}}]}'),
+                              3,
+                             ),
+                             ('product',('{"and":[{"user": {"is_not_null": {}}}]}'),2),
+                             ('product',('{"and":[{"user": {"is_null": {}}}]}'),3),
+                             ('product',
+                              ('{"and":[{"user": {"is_not_null": {}}},{"title": {"eq": "OPPOF19"}}]}'),
+                              1,
+                             ),
+                             ('product',
+                              ('{"or":[{"user": {"is_not_null": {}}},{"title": {"eq": "OPPOF19"}}]}'),
+                              2,
+                             ),
+                         ])
+async def test_api_query6(client: AsyncClient, resource: str, where: tuple[str], total: int):
+    response = await client.get(f"/admin/api/{resource}?where={where}")
+    data = response.json()
+    assert data["total"] == total
+
 
 async def test_detail(client: AsyncClient):
     response = await client.get("/admin/product/detail/1")

--- a/tests/sqla/test_sync_engine.py
+++ b/tests/sqla/test_sync_engine.py
@@ -1,7 +1,7 @@
 import enum
 import json
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import pytest
 import pytest_asyncio
@@ -279,7 +279,7 @@ async def test_api_query5(client: AsyncClient):
     ],
 )
 async def test_api_query6(
-    client: AsyncClient, resource: str, where: tuple[str], total: int
+    client: AsyncClient, resource: str, where: Tuple[str], total: int
 ):
     response = await client.get(f"/admin/api/{resource}?where={where}")
     data = response.json()


### PR DESCRIPTION
When using sqlalchemy as database with the **filter** feature's "Empty" and "Not Empty", it works well for column but not for the relation fields(**HasMany, HasOne**)

![截圖 2023-11-11 下午12 07 31](https://github.com/jowilf/starlette-admin/assets/11798731/fdafa98c-a67e-46ec-9910-762f10304bfa)

throws error
```
# is_not_null
NotImplementedError: <function is_not at 0x105ace200>
# is_null
NotImplementedError: <function is_ at 0x105ace200>
```

Because the operator of sqlalchemy only works on columns not relationship
```
# starlette_admin/contrib/sqla/helpers.py
OPERATORS ={
   ...
    "is_null": lambda f, v: f.is_(None),
    "is_not_null": lambda f, v: f.is_not(None),
}
```

This PR fix this issue