### PR TITLE
Use SQLAlchemy defaults in fields

### DIFF
--- a/examples/sqla/models.py
+++ b/examples/sqla/models.py
@@ -2,6 +2,7 @@ import enum
 from datetime import datetime
 
 from sqlalchemy import (
+    Boolean,
     Column,
     Date,
     DateTime,
@@ -51,9 +52,10 @@ class Post(Base):
     id = Column(Integer, primary_key=True)
     title = Column(String(100), nullable=False)
     text = Column(Text, nullable=False)
-    date = Column(Date)
-    status = Column(Enum(Status))
+    date = Column(Date, default=datetime.today)
+    status = Column(Enum(Status), default=Status.PENDING)
     created_at = Column(DateTime, default=datetime.utcnow)
+    is_public = Column(Boolean, default=True, nullable=False)
 
     publisher_id = Column(Integer, ForeignKey(User.id))
     publisher = relationship(User, back_populates="posts")

--- a/starlette_admin/contrib/sqla/converters.py
+++ b/starlette_admin/contrib/sqla/converters.py
@@ -130,15 +130,30 @@ class ModelConverter(BaseSQLAModelConverter):
                 "exclude_from_edit": True,
                 "exclude_from_create": True,
             }
+
+        default_value = None
+        help_text = column.comment
+        if column.default:
+            if column.default.is_scalar:
+                default_value = column.default.arg
+            elif column.default.is_callable:
+                # Here we can't evaluate even callable default because it requires execution context
+                func_name = column.default.arg.__name__
+                if help_text:
+                    help_text = f"{help_text}. Defaulted to {func_name}"
+                else:
+                    help_text = f"Defaulted to {func_name}"
+
         return {
             "name": name,
-            "help_text": column.comment,
+            "help_text": help_text,
             "required": (
                 not column.nullable
                 and not isinstance(column.type, (Boolean,))
                 and not column.default
                 and not column.server_default
             ),
+            "default": default_value,
         }
 
     @classmethod

--- a/starlette_admin/fields.py
+++ b/starlette_admin/fields.py
@@ -54,6 +54,7 @@ class BaseField:
         search_builder_type: datatable columns.searchBuilderType, For more information
             [click here](https://datatables.net/reference/option/columns.searchBuilderType)
         required: Indicate if the fields is required
+        default: Default value for the field
         exclude_from_list: Control field visibility in list page
         exclude_from_detail: Control field visibility in detail page
         exclude_from_create: Control field visibility in create page
@@ -74,6 +75,7 @@ class BaseField:
     id: str = ""
     search_builder_type: Optional[str] = "default"
     required: Optional[bool] = False
+    default: Optional[Any] = None
     exclude_from_list: Optional[bool] = False
     exclude_from_detail: Optional[bool] = False
     exclude_from_create: Optional[bool] = False
@@ -84,7 +86,7 @@ class BaseField:
     form_template: str = "forms/input.html"
     label_template: str = "forms/_label.html"
     display_template: str = "displays/text.html"
-    error_class = "is-invalid"
+    error_class: str = "is-invalid"
 
     def __post_init__(self) -> None:
         if self.label is None:

--- a/tests/sqla/test_sqla_utils.py
+++ b/tests/sqla/test_sqla_utils.py
@@ -70,14 +70,14 @@ class Model(Base):
     uuid = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
     choice = Column(ChoiceType([(1, "One"), (2, "Two")], impl=Integer()))
     counter = Column(ChoiceType(Counter))
-    arrow = Column(ArrowType, default=arrow.utcnow())
+    arrow = Column(ArrowType, default=arrow.utcnow)
     url = Column(URLType)
     email = Column(EmailType)
     ip_address = Column(IPAddressType)
     country = Column(CountryType)
     color = Column(ColorType)
     timezone = Column(TimezoneType(backend="zoneinfo"))
-    currency = Column(CurrencyType)
+    currency = Column(CurrencyType, default="USD")
     scalars = Column(ScalarListType)
     phonenumber = Column(PhoneNumberType)
     password = Column(
@@ -89,17 +89,22 @@ class Model(Base):
 
 async def test_model_fields_conversion():
     assert ModelView(Model).fields == [
-        StringField("uuid", exclude_from_create=True, exclude_from_edit=True),
+        StringField(
+            "uuid",
+            exclude_from_create=True,
+            exclude_from_edit=True,
+            help_text="Defaulted to uuid4",
+        ),
         EnumField("choice", choices=((1, "One"), (2, "Two")), coerce=int),
         EnumField("counter", enum=Counter, coerce=str),
-        ArrowField("arrow"),
+        ArrowField("arrow", help_text="Defaulted to utcnow"),
         URLField("url"),
         EmailField("email"),
         StringField("ip_address"),
         CountryField("country"),
         ColorField("color"),
         TimeZoneField("timezone", coerce=zoneinfo.ZoneInfo),
-        CurrencyField("currency"),
+        CurrencyField("currency", default="USD"),
         ListField(StringField("scalars")),
         PhoneField("phonenumber"),
         PasswordField("password"),

--- a/tests/sqla/test_view_meta.py
+++ b/tests/sqla/test_view_meta.py
@@ -193,7 +193,12 @@ def test_document_fields_conversion():
 
 def test_other_fields_conversion():
     assert ModelView(Other).fields == [
-        StringField("uuid", exclude_from_create=True, exclude_from_edit=True),
+        StringField(
+            "uuid",
+            exclude_from_create=True,
+            exclude_from_edit=True,
+            help_text="Defaulted to uuid4",
+        ),
         BooleanField("bit"),
         IntegerField("year", min=1901, max=2155),
         StringField("macaddr"),


### PR DESCRIPTION
Now, if a SQLA Column has a default value, it is used in the admin panel. If it is a scalar, then the value is used directly. If it is a function or SQL expression, the extra help text is displayed.

![image](https://github.com/jowilf/starlette-admin/assets/10210242/cd2bbadc-4405-41a0-800f-93badf149081)
