### PR TITLE
Ability to use Jinja2 templates in action forms

### DIFF
--- a/docs/tutorial/actions/index.md
+++ b/docs/tutorial/actions/index.md
@@ -115,7 +115,7 @@ generated html element (e.g. `<a href='https://example.com/?pk=4' ...>`).
 ### Example
 
 ```python
-from typing import Any
+from typing import Any, Dict
 
 from starlette.datastructures import FormData
 from starlette.requests import Request
@@ -145,10 +145,8 @@ class ArticleView(ModelView):
             EnumField("status", choices=['draft', 'published', 'rejected'], select2=True)
         ],
     )
-    async def make_published_row_action(self, request: Request, pk: Any) -> str:
+    async def make_published_row_action(self, request: Request, pk: Any, data: Dict) -> str:
         # Write your logic here
-
-        data: FormData = await request.form()
         article_status = data.get("status")
 
         if ...:

--- a/docs/tutorial/actions/index.md
+++ b/docs/tutorial/actions/index.md
@@ -120,6 +120,7 @@ from typing import Any
 from starlette.datastructures import FormData
 from starlette.requests import Request
 
+from starlette_admin import EnumField
 from starlette_admin._types import RowActionsDisplayType
 from starlette_admin.actions import link_row_action, row_action
 from starlette_admin.contrib.sqla import ModelView
@@ -140,25 +141,21 @@ class ArticleView(ModelView):
         submit_btn_text="Yes, proceed",
         submit_btn_class="btn-success",
         action_btn_class="btn-info",
-        form="""
-        <form>
-            <div class="mt-3">
-                <input type="text" class="form-control" name="example-text-input" placeholder="Enter value">
-            </div>
-        </form>
-        """,
+        form_fields=[
+            EnumField("status", choices=['draft', 'published', 'rejected'], select2=True)
+        ],
     )
     async def make_published_row_action(self, request: Request, pk: Any) -> str:
         # Write your logic here
 
         data: FormData = await request.form()
-        user_input = data.get("example-text-input")
+        article_status = data.get("status")
 
         if ...:
             # Display meaningfully error
             raise ActionFailed("Sorry, We can't proceed this action now.")
         # Display successfully message
-        return "The article was successfully marked as published"
+        return f"The article status was changed to {article_status}"
 
     @link_row_action(
         name="go_to_example",

--- a/examples/sqla/views.py
+++ b/examples/sqla/views.py
@@ -1,19 +1,32 @@
 from datetime import date, timedelta
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from sqlalchemy.exc import IntegrityError
 from starlette.requests import Request
-from starlette_admin import EnumField, ExportType, StringField
+from starlette_admin import (
+    EnumField,
+    ExportType,
+    HasOne,
+    StringField,
+    action,
+    row_action,
+)
 from starlette_admin.contrib.sqla import ModelView
-from starlette_admin.exceptions import FormValidationError
+from starlette_admin.exceptions import ActionFailed, FormValidationError
 
-from .models import Post, User
+from .models import Post, Tag, User
 
 AVAILABLE_USER_TYPES = [
     ("admin", "Admin"),
     ("content-writer", "Content writer"),
     ("editor", "Editor"),
     ("regular-user", "Regular user"),
+]
+
+AVAILABLE_POST_STATUSES = [
+    ("pending", "Pending"),
+    ("rejected", "Rejected"),
+    ("approved", "Approved"),
 ]
 
 
@@ -54,6 +67,43 @@ class PostView(ModelView):
         if len(errors) > 0:
             raise FormValidationError(errors)
         return await super().validate(request, data)
+
+    @action(
+        name="add_tag",
+        text="Add a tag for selected posts",
+        icon_class="fas fa-tag",
+        confirmation="Are you sure you want to add a tag to all of these posts?",
+        form_fields=[HasOne("tag", identity="tag")],
+    )
+    async def add_tag(self, request: Request, pks: List[Any]):
+        form = await request.form()
+        tag_pk = form["tag"]
+        tag = await TagView(Tag).find_by_pk(request, tag_pk)
+        if not tag:
+            raise ActionFailed("Tag is missing")
+        posts = await self.find_by_pks(request, pks)
+        for post in posts:
+            post.tags.append(tag)
+
+        request.state.session.commit()
+        return f"Successfully added tag {tag.name} to selected posts"
+
+    @row_action(
+        name="approve",
+        text="Approve selected posts",
+        icon_class="fas fa-tag",
+        confirmation="Are you sure you want to change selected posts' status?",
+        form_fields=[
+            EnumField("status", choices=AVAILABLE_POST_STATUSES, select2=False)
+        ],
+    )
+    async def approve(self, request: Request, pk: Any):
+        form = await request.form()
+        status = form["status"]
+        post = await self.find_by_pk(request, pk)
+        post.status = status
+        request.state.session.commit()
+        return f"Post status successfully changed to {status}"
 
 
 class TagView(ModelView):

--- a/starlette_admin/actions.py
+++ b/starlette_admin/actions.py
@@ -1,6 +1,8 @@
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, Sequence
 
 from starlette_admin.i18n import lazy_gettext as _
+
+from .fields import BaseField
 
 
 def action(
@@ -11,6 +13,8 @@ def action(
     submit_btn_text: Optional[str] = _("Yes, Proceed"),
     icon_class: Optional[str] = None,
     form: Optional[str] = None,
+    form_template: Optional[str] = "forms/action_form.html",
+    form_fields: Optional[Sequence[BaseField]] = None,
     custom_response: Optional[bool] = False,
 ) -> Callable[[Callable[..., Awaitable[str]]], Any]:
     """
@@ -26,6 +30,8 @@ def action(
                 `btn-outline-danger`, ...)
         icon_class: Icon class (ex. `fa-lite fa-folder`, `fa-duotone fa-circle-right`, ...)
         form: Custom form to collect data from user
+        form_template: Custom action form template file
+        form_fields: Fields of the form template
         custom_response: Set to True when you want to return a custom Starlette response
             from your action instead of a string.
 
@@ -91,6 +97,8 @@ def action(
             "submit_btn_class": submit_btn_class,
             "icon_class": icon_class,
             "form": form if form is not None else "",
+            "form_template": form_template,
+            "form_fields": form_fields or [],
             "custom_response": custom_response,
         }
         return f
@@ -107,6 +115,8 @@ def row_action(
     submit_btn_text: Optional[str] = _("Yes, Proceed"),
     icon_class: Optional[str] = None,
     form: Optional[str] = None,
+    form_template: Optional[str] = "forms/action_form.html",
+    form_fields: Optional[Sequence[BaseField]] = None,
     custom_response: Optional[bool] = False,
     exclude_from_list: bool = False,
     exclude_from_detail: bool = False,
@@ -123,6 +133,8 @@ def row_action(
         submit_btn_text: Text for the submit button.
         icon_class: Icon class (ex. `fa-lite fa-folder`, `fa-duotone fa-circle-right`, ...)
         form: Custom HTML to collect data from the user.
+        form_template: Custom action form template file
+        form_fields: Fields of the form template
         custom_response: Set to True when you want to return a custom Starlette response
             from your action instead of a string.
         exclude_from_list: Set to True to exclude the action from the list view.
@@ -163,6 +175,8 @@ def row_action(
             "submit_btn_class": submit_btn_class,
             "icon_class": icon_class,
             "form": form if form is not None else "",
+            "form_template": form_template,
+            "form_fields": form_fields or [],
             "custom_response": custom_response,
             "exclude_from_list": exclude_from_list,
             "exclude_from_detail": exclude_from_detail,

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -350,6 +350,10 @@ class BaseAdmin:
             return JSONResponse({"msg": handler_return})
         except ActionFailed as exc:
             return JSONResponse({"msg": exc.msg}, status_code=HTTP_400_BAD_REQUEST)
+        except FormValidationError as exc:
+            return JSONResponse(
+                {"errors": exc.errors}, status_code=HTTP_422_UNPROCESSABLE_ENTITY
+            )
 
     async def handle_row_action(self, request: Request) -> Response:
         request.state.action = RequestAction.ROW_ACTION
@@ -366,6 +370,10 @@ class BaseAdmin:
             return JSONResponse({"msg": handler_return})
         except ActionFailed as exc:
             return JSONResponse({"msg": exc.msg}, status_code=HTTP_400_BAD_REQUEST)
+        except FormValidationError as exc:
+            return JSONResponse(
+                {"errors": exc.errors}, status_code=HTTP_422_UNPROCESSABLE_ENTITY
+            )
 
     async def _render_list(self, request: Request) -> Response:
         request.state.action = RequestAction.LIST

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -380,6 +380,7 @@ class BaseAdmin:
                 "model": model,
                 "title": model.title(request),
                 "_actions": await model.get_all_actions(request),
+                "_row_actions": await model.get_all_row_actions(request),
                 "__js_model__": await model._configs(request),
             },
         )
@@ -402,6 +403,7 @@ class BaseAdmin:
                 "model": model,
                 "raw_obj": obj,
                 "_actions": await model.get_all_row_actions(request),
+                "_row_actions": await model.get_all_row_actions(request),
                 "obj": await model.serialize(obj, request, RequestAction.DETAIL),
             },
         )

--- a/starlette_admin/contrib/sqla/view.py
+++ b/starlette_admin/contrib/sqla/view.py
@@ -169,6 +169,12 @@ class ModelView(BaseModelView):
                 self.pk_field = StringField(_pk_attrs[0])
         self.pk_attr = self.pk_field.name
 
+    async def parse_form(
+        self, request: Request, form_fields: Sequence[BaseField]
+    ) -> Dict:
+        data = await super().parse_form(request, form_fields)
+        return await self.arrange_data_for_fields(request, data, form_fields)
+
     async def handle_action(
         self, request: Request, pks: List[Any], name: str
     ) -> Union[str, Response]:
@@ -521,13 +527,22 @@ class ModelView(BaseModelView):
         request: Request,
         data: Dict[str, Any],
         is_edit: bool = False,
+    ):
+        fields = self.get_fields_list(request, request.state.action)
+        return await self.arrange_data_for_fields(request, data, fields)
+
+    async def arrange_data_for_fields(
+        self,
+        request: Request,
+        data: Dict[str, Any],
+        fields: Sequence[BaseField],
     ) -> Dict[str, Any]:
         """
         This function will return a new dict with relationships loaded from
         database.
         """
         arranged_data: Dict[str, Any] = {}
-        for field in self.get_fields_list(request, request.state.action):
+        for field in fields:
             if isinstance(field, RelationField) and data[field.name] is not None:
                 foreign_model = self._find_foreign_model(field.identity)  # type: ignore
                 if not field.multiple:

--- a/starlette_admin/contrib/sqla/view.py
+++ b/starlette_admin/contrib/sqla/view.py
@@ -527,7 +527,7 @@ class ModelView(BaseModelView):
         request: Request,
         data: Dict[str, Any],
         is_edit: bool = False,
-    ):
+    ) -> Dict[str, Any]:
         fields = self.get_fields_list(request, request.state.action)
         return await self.arrange_data_for_fields(request, data, fields)
 

--- a/starlette_admin/fields.py
+++ b/starlette_admin/fields.py
@@ -449,16 +449,14 @@ class TagsField(BaseField):
         return []
 
     def additional_js_links(self, request: Request, action: RequestAction) -> List[str]:
-        if action.is_form():
-            return [
-                str(
-                    request.url_for(
-                        f"{request.app.state.ROUTE_NAME}:statics",
-                        path="js/vendor/select2.min.js",
-                    )
+        return [
+            str(
+                request.url_for(
+                    f"{request.app.state.ROUTE_NAME}:statics",
+                    path="js/vendor/select2.min.js",
                 )
-            ]
-        return []
+            )
+        ]
 
 
 @dataclass
@@ -601,7 +599,7 @@ class EnumField(StringField):
     def additional_css_links(
         self, request: Request, action: RequestAction
     ) -> List[str]:
-        if self.select2 and action.is_form():
+        if self.select2:
             return [
                 str(
                     request.url_for(
@@ -613,7 +611,7 @@ class EnumField(StringField):
         return []
 
     def additional_js_links(self, request: Request, action: RequestAction) -> List[str]:
-        if self.select2 and action.is_form():
+        if self.select2:
             return [
                 str(
                     request.url_for(
@@ -1058,28 +1056,24 @@ class RelationField(BaseField):
     def additional_css_links(
         self, request: Request, action: RequestAction
     ) -> List[str]:
-        if action.is_form():
-            return [
-                str(
-                    request.url_for(
-                        f"{request.app.state.ROUTE_NAME}:statics",
-                        path="css/select2.min.css",
-                    )
+        return [
+            str(
+                request.url_for(
+                    f"{request.app.state.ROUTE_NAME}:statics",
+                    path="css/select2.min.css",
                 )
-            ]
-        return []
+            )
+        ]
 
     def additional_js_links(self, request: Request, action: RequestAction) -> List[str]:
-        if action.is_form():
-            return [
-                str(
-                    request.url_for(
-                        f"{request.app.state.ROUTE_NAME}:statics",
-                        path="js/vendor/select2.min.js",
-                    )
+        return [
+            str(
+                request.url_for(
+                    f"{request.app.state.ROUTE_NAME}:statics",
+                    path="js/vendor/select2.min.js",
                 )
-            ]
-        return []
+            )
+        ]
 
 
 @dataclass

--- a/starlette_admin/statics/js/actions.js
+++ b/starlette_admin/statics/js/actions.js
@@ -1,5 +1,5 @@
 /**
- * A class for managing bactch and row actions in the admin interface.
+ * A class for managing batch and row actions in the admin interface.
  */
 class ActionManager {
   /**
@@ -41,26 +41,17 @@ class ActionManager {
    */
   initActionModal() {
     let self = this;
-    $("#modal-action").on("show.bs.modal", function (event) {
+    $("[data-action-modal]").on("show.bs.modal", function (event) {
       let button = $(event.relatedTarget); // Button that triggered the modal
-      let confirmation = button.data("confirmation");
-      let form = button.data("form");
       let name = button.data("name");
-      let submit_btn_text = button.data("submit-btn-text");
-      let submit_btn_class = button.data("submit-btn-class");
       let customResponse = button.data("custom-response") === true;
       let isRowAction = button.data("is-row-action") === true;
 
       let modal = $(this);
-      modal.find("#actionConfirmation").text(confirmation);
-      let modalForm = modal.find("#modal-form");
-      modalForm.html(form);
-      let actionSubmit = modal.find("#actionSubmit");
-      actionSubmit.text(submit_btn_text);
-      actionSubmit.removeClass().addClass(`btn ${submit_btn_class}`);
+      let actionSubmit = modal.find("[data-action-submit]");
       actionSubmit.unbind();
       actionSubmit.on("click", function (event) {
-        const formElements = modalForm.find("form");
+        const formElements = modal.find("form");
         const form = formElements.length ? formElements.get(0) : null;
         self.submitAction(name, form, customResponse, isRowAction, button);
       });

--- a/starlette_admin/statics/js/actions.js
+++ b/starlette_admin/statics/js/actions.js
@@ -53,7 +53,7 @@ class ActionManager {
       actionSubmit.on("click", function (event) {
         const formElements = modal.find("form");
         const form = formElements.length ? formElements.get(0) : null;
-        self.submitAction(name, form, customResponse, isRowAction, button);
+        self.submitAction(name, form, customResponse, isRowAction, button, modal).then();
       });
     });
   }
@@ -65,8 +65,9 @@ class ActionManager {
    * @param {boolean} customResponse
    * @param {boolean} isRowAction - Whether the action is a row action.
    * @param {jQuery} element - The element that triggered the action.
+   * @param {jQuery} modal - The modal element.
    */
-  submitAction(actionName, form, customResponse, isRowAction, element) {
+  async submitAction(actionName, form, customResponse, isRowAction, element, modal) {
     let baseUrl = isRowAction ? this.rowActionUrl : this.actionUrl;
     let query = new URLSearchParams();
     query.append("name", actionName);
@@ -81,28 +82,58 @@ class ActionManager {
         window.location.replace(url);
       }
     } else {
-      $("#modal-loading").modal("show");
-      fetch(url, {
-        method: form ? "POST" : "GET",
-        body: form ? new FormData(form) : null,
-      })
-        .then(async (response) => {
-          await new Promise((r) => setTimeout(r, 500));
-          $("#modal-loading").modal("hide");
-          if (response.ok) {
-            let msg = (await response.json())["msg"];
-            this.onSuccess(actionName, element, msg);
-          } else {
-            if (response.status == 400) {
-              return Promise.reject((await response.json())["msg"]);
-            }
-            return Promise.reject("Something went wrong!");
-          }
-        })
-        .catch(async (error) => {
-          await new Promise((r) => setTimeout(r, 500));
-          this.onError(actionName, element, error);
+      modal.find("[data-form]").hide(0, () => {
+        modal.find("[data-loading]").show();
+      });
+      try {
+        const response = await fetch(url, {
+          method: form ? "POST" : "GET",
+          body: form ? new FormData(form) : null,
         });
+        await new Promise((r) => setTimeout(r, 500));
+        modal.find("[data-loading]").hide(0, () => {
+          modal.find("[data-form]").show();
+        });
+
+        if (response.ok) {
+          const responseData = await response.json();
+          let msg = responseData["msg"];
+          this.onSuccess(actionName, element, msg);
+        } else if (response.status === 400) {
+          // Action error
+          const responseData = await response.json();
+          let error = responseData["msg"];
+          this.onError(actionName, element, error);
+        } else if (response.status === 422) {
+          // Validation error, let's show errors
+          const responseData = await response.json();
+          $('.invalid-feedback', modal).each(function () {
+            let e = $(this);
+            const fieldName = e.data('fieldName');
+            const errText = responseData['errors'][fieldName];
+            const inputElement = $(`:input[name="${fieldName}"]`, modal);
+            if (errText) {
+              inputElement.parent().addClass("is-invalid");
+              inputElement.addClass("is-invalid");
+              e.text(errText);
+              e.show();
+            } else {
+              inputElement.parent().removeClass("is-invalid");
+              inputElement.removeClass("is-invalid");
+              e.text("");
+              e.hide();
+            }
+          })
+          return;
+        } else {
+          // Internal server error
+          this.onError(actionName, element, "Something went wrong!");
+        }
+      } catch (error) {
+        await new Promise((r) => setTimeout(r, 500));
+        this.onError(actionName, element, error);
+      }
+      modal.modal('hide');
     }
   }
 }

--- a/starlette_admin/statics/js/form.js
+++ b/starlette_admin/statics/js/form.js
@@ -131,6 +131,8 @@ registerFieldInitializer(function (element) {
         }
       });
   });
+  $('.select2-container').css('width','100%');
+
   $("input.field-datetime", element).each(function () {
     let el = $(this);
     el.flatpickr({

--- a/starlette_admin/templates/actions.html
+++ b/starlette_admin/templates/actions.html
@@ -13,8 +13,7 @@
                href="#"
                     {% if action.confirmation is not none %}
                data-bs-toggle="modal"
-               data-bs-target="#modal-action"
-               data-confirmation="{{ action.confirmation }}"
+               data-bs-target="#modal-action-{{ action.name }}"
                     {% else %}
                data-no-confirmation-action="true"
                     {% endif %}
@@ -22,9 +21,6 @@
                data-custom-response="true"
                     {% endif %}
                data-name="{{ action.name }}"
-               data-submit-btn-text="{{ action.submit_btn_text }}"
-               data-submit-btn-class="{{ action.submit_btn_class }}"
-               data-form="{{ action.form }}"
             >
                 {% if action.icon_class %}
                     <i class="{{ action.icon_class }} me-2"></i>

--- a/starlette_admin/templates/create.html
+++ b/starlette_admin/templates/create.html
@@ -30,7 +30,7 @@
                             {% block create_form %}
                                 {% for field in model.get_fields_list(request, 'CREATE' | ra) %}
                                     <div class="mb-3">
-                                        {% with action=('CREATE'| ra), data=(None if not obj else obj[field.name]), error=errors.get(field.name, None) if errors else None %}
+                                        {% with request_action=('CREATE'| ra), data=(None if not obj else obj[field.name]), error=errors.get(field.name, None) if errors else None %}
                                             {% include field.label_template %}
                                             {% include field.form_template %}
                                         {% endwith %}

--- a/starlette_admin/templates/edit.html
+++ b/starlette_admin/templates/edit.html
@@ -32,7 +32,7 @@
                             {% block edit_form %}
                                 {% for field in model.get_fields_list(request, 'EDIT' | ra) %}
                                     <div class="mb-3">
-                                        {% with action=('EDIT' | ra),data=obj[field.name], error=errors.get(field.name, None) if errors else None %}
+                                        {% with request_action=('EDIT' | ra),data=obj[field.name], error=errors.get(field.name, None) if errors else None %}
                                             {% include field.label_template %}
                                             {% include field.form_template %}
                                         {% endwith %}

--- a/starlette_admin/templates/forms/_error.html
+++ b/starlette_admin/templates/forms/_error.html
@@ -1,3 +1,3 @@
 <div data-field-name="{{ field.name }}"
-     class="invalid-feedback"
-     {% if not error %}style="display: none;"{% endif %}>{{ error }}</div>
+     {% if not error %}style="display: none;"{% endif %}
+     class="invalid-feedback">{{ error }}</div>

--- a/starlette_admin/templates/forms/_error.html
+++ b/starlette_admin/templates/forms/_error.html
@@ -1,3 +1,3 @@
-{% if error %}
-    <div class="invalid-feedback">{{ error }}</div>
-{% endif %}
+<div data-field-name="{{ field.name }}"
+     class="invalid-feedback"
+     {% if not error %}style="display: none;"{% endif %}>{{ error }}</div>

--- a/starlette_admin/templates/forms/action_form.html
+++ b/starlette_admin/templates/forms/action_form.html
@@ -1,0 +1,10 @@
+<form>
+    {% for field in action.form_fields %}
+        <div class="mt-3">
+            {% with request_action=('ACTION'| ra) %}
+                {% include field.label_template %}
+                {% include field.form_template %}
+            {% endwith %}
+        </div>
+    {% endfor %}
+</form>

--- a/starlette_admin/templates/forms/collection.html
+++ b/starlette_admin/templates/forms/collection.html
@@ -1,5 +1,5 @@
 <fieldset class="form-fieldset">
-    {% for field in field.get_fields_list(request, action) %}
+    {% for field in field.get_fields_list(request, request_action) %}
         <div class="form-group row mb-3">
             <label class="col-3 col-form-label {% if field.required %}required{% endif %}"
                    for="{{ field.id }}">{{ field.label }}</label>

--- a/starlette_admin/templates/forms/enum.html
+++ b/starlette_admin/templates/forms/enum.html
@@ -1,6 +1,7 @@
 <div class="{% if error %}{{ field.error_class }}{% endif %}">
     <select id="{{ field.id }}"
             name="{{ field.id }}"
+            {% if action %}data-dropdown-parent="#modal-action-{{ action.name }}"{% endif %}
             data-allow-clear="true"
             data-placeholder="{{ _('Select a %(label)s', label=field.label) }}"
             class="{{ field.class_ }} {% if error %}{{ field.error_class }}{% endif %}"

--- a/starlette_admin/templates/forms/file.html
+++ b/starlette_admin/templates/forms/file.html
@@ -6,7 +6,7 @@
     {% endif %}
 </div>
 {% include "forms/_error.html" %}
-{% if action=='EDIT' and field._isvalid_value(data) %}
+{% if request_action=='EDIT' and field._isvalid_value(data) %}
     <div class="mt-2 border p-2">
         {% include "displays/file.html" %}
         {% include "forms/_delete.html" %}

--- a/starlette_admin/templates/forms/image.html
+++ b/starlette_admin/templates/forms/image.html
@@ -6,7 +6,7 @@
     {% endif %}
 </div>
 {% include "forms/_error.html" %}
-{% if action=='EDIT' and field._isvalid_value(data) %}
+{% if request_action=='EDIT' and field._isvalid_value(data) %}
     <div class="mt-2 border p-2">
         {% include "displays/image.html" %}
         {% include "forms/_delete.html" %}

--- a/starlette_admin/templates/forms/relation.html
+++ b/starlette_admin/templates/forms/relation.html
@@ -2,6 +2,7 @@
 {% set fpk = foreign_model.pk_attr %}
 <div class="{% if error %}{{ field.error_class }}{% endif %}">
     <select data-allow-clear="true"
+            {% if action %}data-dropdown-parent="#modal-action-{{ action.name }}"{% endif %}
             data-placeholder="Select {{ field.id }}"
             id="{{ field.id }}"
             name="{{ field.id }}"

--- a/starlette_admin/templates/forms/tags.html
+++ b/starlette_admin/templates/forms/tags.html
@@ -1,6 +1,7 @@
 <div class="{% if error %}{{ field.error_class }}{% endif %}">
     <select id="{{ field.id }}"
             name="{{ field.id }}"
+            {% if action %}data-dropdown-parent="#modal-action-{{ action.name }}"{% endif %}
             class="{{ field.class_ }} {% if error %}{{ field.error_class }}{% endif %}"
             data-tags="true"
             multiple>

--- a/starlette_admin/templates/list.html
+++ b/starlette_admin/templates/list.html
@@ -157,4 +157,6 @@
             src="{{ url_for(__name__ ~ ':statics', path='js/actions.js') }}"></script>
     <script type="text/javascript"
             src="{{ url_for(__name__ ~ ':statics', path='js/list.js') }}"></script>
+    <script type="text/javascript"
+            src="{{ url_for(__name__ ~ ':statics', path='js/form.js') }}"></script>
 {% endblock %}

--- a/starlette_admin/templates/list.html
+++ b/starlette_admin/templates/list.html
@@ -118,6 +118,10 @@
             margin-top: 0px !important;
             margin-bottom: 0px !important;
         }
+
+        .is-invalid .select2-selection {
+            border-color: #d63939 !important;
+        }
     </style>
 {% endblock %}
 {% block script %}

--- a/starlette_admin/templates/modals/actions.html
+++ b/starlette_admin/templates/modals/actions.html
@@ -1,16 +1,27 @@
-<div class="modal modal-blur fade" id="modal-action" tabindex="-1" role="dialog" aria-hidden="true">
+{% for action in _actions + _row_actions %}
+<div data-action-modal class="modal modal-blur fade" id="modal-action-{{ action.name }}" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-body">
-                <div id="actionConfirmation"></div>
-                <div id="modal-form"></div>
+                <div>{{ action.confirmation }}</div>
+                <div>
+                    {% if action.form %}
+                        {{ action.form | safe }}
+                    {% elif action.form_template %}
+                        {% include action.form_template %}
+                    {% endif %}
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-link link-secondary me-auto"
                         data-bs-dismiss="modal">{{ _("Cancel") }}</button>
-                <button id="actionSubmit" type="button" class="btn btn-primary"
-                        data-bs-dismiss="modal">{{ _("Yes, Proceed") }}</button>
+                <button type="button" class="btn {{ action.submit_btn_class | default("btn-primary", true) }}"
+                        data-action-submit
+                        data-bs-dismiss="modal">
+                    {{ action.submit_btn_text | default(_("Yes, Proceed"), true) }}
+                </button>
             </div>
         </div>
     </div>
 </div>
+{% endfor %}

--- a/starlette_admin/templates/modals/actions.html
+++ b/starlette_admin/templates/modals/actions.html
@@ -3,21 +3,28 @@
     <div class="modal-dialog modal-sm modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-body">
-                <div>{{ action.confirmation }}</div>
-                <div>
-                    {% if action.form %}
-                        {{ action.form | safe }}
-                    {% elif action.form_template %}
-                        {% include action.form_template %}
-                    {% endif %}
+                <div data-loading style="display: none;">
+                    <div class="d-flex justify-content-center">
+                        <div class="spinner-border text-primary" role="status"></div>
+                        <span class="ms-2">{{ _("Loading") }}...</span>
+                    </div>
+                </div>
+                <div data-form>
+                    <div>{{ action.confirmation }}</div>
+                    <div>
+                        {% if action.form %}
+                            {{ action.form | safe }}
+                        {% elif action.form_template %}
+                            {% include action.form_template %}
+                        {% endif %}
+                    </div>
                 </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-link link-secondary me-auto"
                         data-bs-dismiss="modal">{{ _("Cancel") }}</button>
                 <button type="button" class="btn {{ action.submit_btn_class | default("btn-primary", true) }}"
-                        data-action-submit
-                        data-bs-dismiss="modal">
+                        data-action-submit>
                     {{ action.submit_btn_text | default(_("Yes, Proceed"), true) }}
                 </button>
             </div>

--- a/starlette_admin/templates/row-actions.html
+++ b/starlette_admin/templates/row-actions.html
@@ -5,17 +5,13 @@
         href="#"
         {% if action.confirmation is not none -%}
             data-bs-toggle="modal"
-            data-bs-target="#modal-action"
-            data-confirmation="{{ action.confirmation }}"
+            data-bs-target="#modal-action-{{ action.name }}"
         {% else %}
             data-no-confirmation-action="true"
         {% endif %}
         {% if action.custom_response -%}
             data-custom-response="true"
         {% endif %}
-        data-submit-btn-text="{{ action.submit_btn_text }}"
-        data-submit-btn-class="{{ action.submit_btn_class }}"
-        data-form="{{ action.form }}"
     {% endif %}
     data-is-row-action="true"
     data-name="{{ action.name }}"

--- a/starlette_admin/templates/row-actions.html
+++ b/starlette_admin/templates/row-actions.html
@@ -1,6 +1,6 @@
 {% macro action_data_attributes(action) -%}
     {% if action.is_link -%}
-        href="{{ model._row_actions_handlers.get(action.name)(request, pk) }}"
+        href="{{ model._row_actions_handlers.get(action.name)(request, pk, {}) }}"
     {% else %}
         href="#"
         {% if action.confirmation is not none -%}

--- a/starlette_admin/views.py
+++ b/starlette_admin/views.py
@@ -1,3 +1,4 @@
+import functools
 import inspect
 from abc import abstractmethod
 from collections import OrderedDict
@@ -17,6 +18,7 @@ from typing import (
 
 from jinja2 import Template
 from multipart.exceptions import MultipartParseError
+from starlette.datastructures import FormData
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.templating import Jinja2Templates
@@ -308,18 +310,10 @@ class BaseModelView(BaseView):
         self._actions: Dict[str, Dict[str, Any]] = OrderedDict()
         self._row_actions: Dict[str, Dict[str, Any]] = OrderedDict()
         self._actions_handlers: Dict[
-            str,
-            Union[
-                Callable[[Request, Sequence[Any]], Awaitable],
-                Callable[[Request, Sequence[Any], Dict], Awaitable],
-            ],
+            str, Callable[[Request, Sequence[Any], Dict], Awaitable]
         ] = OrderedDict()
         self._row_actions_handlers: Dict[
-            str,
-            Union[
-                Callable[[Request, Any], Awaitable],
-                Callable[[Request, Any, Dict], Awaitable],
-            ],
+            str, Callable[[Request, Any, Dict], Awaitable]
         ] = OrderedDict()
         self._init_actions()
 
@@ -336,25 +330,58 @@ class BaseModelView(BaseView):
         This method initializes batch and row actions, collects their handlers,
         and validates that all specified actions exist.
         """
+
+        def wrap(
+            fn: Callable[[Request, Sequence[Any]], Awaitable]
+        ) -> Callable[[Request, Sequence[Any], Dict], Awaitable]:
+            @functools.wraps(fn)
+            async def wrapper(r: Request, pks: Sequence[Any], d: Dict) -> Any:
+                return await fn(r, pks)
+
+            return wrapper
+
         for _method_name, method in inspect.getmembers(
             self, predicate=inspect.ismethod
         ):
             if hasattr(method, "_action"):
                 name = method._action.get("name")
                 self._actions[name] = method._action
-                self._actions_handlers[name] = method
+
+                s = inspect.signature(method)
+                if len(s.parameters) == 3:
+                    self._actions_handlers[name] = method
+                elif len(s.parameters) == 2:
+                    self._actions_handlers[name] = wrap(method)
+                else:
+                    raise TypeError("Wrong number of arguments")
 
         if self.actions is None:
             self.actions = list(self._actions_handlers.keys())
 
     def _init_row_actions(self) -> None:
+        def wrap(
+            fn: Callable[[Request, Any], Awaitable]
+        ) -> Callable[[Request, Any, Dict], Awaitable]:
+            @functools.wraps(fn)
+            async def wrapper(r: Request, pk: Any, d: Dict) -> Any:
+                return await fn(r, pk)
+
+            return wrapper
+
         for _method_name, method in inspect.getmembers(
             self, predicate=inspect.ismethod
         ):
             if hasattr(method, "_row_action"):
                 name = method._row_action.get("name")
                 self._row_actions[name] = method._row_action
-                self._row_actions_handlers[name] = method
+
+                s = inspect.signature(method)
+                if len(s.parameters) == 3:
+                    self._row_actions_handlers[name] = method
+                elif len(s.parameters) == 2:
+                    self._row_actions_handlers[name] = wrap(method)
+                else:
+                    raise TypeError("Wrong number of arguments")
 
         if self.row_actions is None:
             self.row_actions = list(self._row_actions_handlers.keys())
@@ -431,7 +458,7 @@ class BaseModelView(BaseView):
         except MultipartParseError:
             # For empty FormData, `fetch` doesn't set Content-Type and therefore Starlette cannot parse the form.
             # https://stackoverflow.com/questions/39280438/fetch-missing-boundary-in-multipart-form-data-post
-            data = {}
+            data = FormData()
 
         return {
             f.name: await f.parse_form_data(request, data, request.state.action)
@@ -453,11 +480,8 @@ class BaseModelView(BaseView):
             raise ActionFailed("Forbidden")
 
         form_fields: List[BaseField] = self._actions[name]["form_fields"]
-        if form_fields:
-            data = await self.parse_form(request, form_fields)
-            handler_return = await handler(request, pks, data)
-        else:
-            handler_return = await handler(request, pks)
+        data = await self.parse_form(request, form_fields)
+        handler_return = await handler(request, pks, data)
         custom_response = self._actions[name]["custom_response"]
         if isinstance(handler_return, Response) and not custom_response:
             raise ActionFailed(
@@ -480,11 +504,8 @@ class BaseModelView(BaseView):
             raise ActionFailed("Forbidden")
 
         form_fields: List[BaseField] = self._row_actions[name]["form_fields"]
-        if form_fields:
-            data = await self.parse_form(request, form_fields)
-            handler_return = await handler(request, pk, data)
-        else:
-            handler_return = await handler(request, pk)
+        data = await self.parse_form(request, form_fields)
+        handler_return = await handler(request, pk, data)
         custom_response = self._row_actions[name]["custom_response"]
         if isinstance(handler_return, Response) and not custom_response:
             raise ActionFailed(

--- a/tests/mongoengine/test_auth.py
+++ b/tests/mongoengine/test_auth.py
@@ -61,7 +61,7 @@ class TestFieldAccess:
             "/admin/post/create", cookies={"session": user_session}
         )
         assert response.status_code == 200
-        assert response.text.count('name="super_admin_only_field"') == expected_value
+        assert response.text.count(' name="super_admin_only_field"') == expected_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -104,7 +104,7 @@ class TestFieldAccess:
             f"/admin/post/edit/{post.id}", cookies={"session": user_session}
         )
         assert response.status_code == 200
-        assert response.text.count('name="super_admin_only_field"') == expected_value
+        assert response.text.count(' name="super_admin_only_field"') == expected_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/mongoengine/test_view.py
+++ b/tests/mongoengine/test_view.py
@@ -220,10 +220,7 @@ class TestMongoBasic:
             },
         )
         assert response.status_code == 422
-        assert (
-            '<div class="invalid-feedback">String value is too short</div>'
-            in response.text
-        )
+        assert 'class="invalid-feedback">String value is too short' in response.text
         assert Product.objects.count() == 5
         with pytest.raises(me.DoesNotExist):
             Product.objects(brand="Infinix").get()
@@ -264,10 +261,7 @@ class TestMongoBasic:
             },
         )
         assert response.status_code == 422
-        assert (
-            '<div class="invalid-feedback">String value is too short</div>'
-            in response.text
-        )
+        assert 'class="invalid-feedback">String value is too short' in response.text
         assert Product.objects.count() == 5
         with pytest.raises(me.DoesNotExist):
             Product.objects(brand="Infinix").get()

--- a/tests/odmantic/test_async_engine.py
+++ b/tests/odmantic/test_async_engine.py
@@ -206,7 +206,7 @@ async def test_create_validation_error(client: AsyncClient, aio_engine: AIOEngin
         },
         follow_redirects=False,
     )
-    assert response.text.count('<div class="invalid-feedback">') == 3
+    assert response.text.count('class="invalid-feedback">') == 3
     assert response.text.count("ensure this value has at least 3 characters") == 1
     assert response.text.count("ensure this value has at least 5 characters") == 1
     assert response.text.count("ensure this value has at most 10 characters") == 1
@@ -264,7 +264,7 @@ async def test_edit_validation_error(client: AsyncClient, aio_engine: AIOEngine)
         },
         follow_redirects=False,
     )
-    assert response.text.count('<div class="invalid-feedback">') == 3
+    assert response.text.count('class="invalid-feedback">') == 3
     assert response.text.count("ensure this value has at least 3 characters") == 1
     assert response.text.count("ensure this value has at least 5 characters") == 1
     assert response.text.count("ensure this value has at most 10 characters") == 1

--- a/tests/odmantic/test_auth.py
+++ b/tests/odmantic/test_auth.py
@@ -53,7 +53,7 @@ class TestFieldAccess:
             "/admin/post/create", cookies={"session": user_session}
         )
         assert response.status_code == 200
-        assert response.text.count('name="super_admin_only_field"') == expected_value
+        assert response.text.count(' name="super_admin_only_field"') == expected_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -102,7 +102,7 @@ class TestFieldAccess:
             f"/admin/post/edit/{post.id}", cookies={"session": user_session}
         )
         assert response.status_code == 200
-        assert response.text.count('name="super_admin_only_field"') == expected_value
+        assert response.text.count(' name="super_admin_only_field"') == expected_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/sqla/test_auth.py
+++ b/tests/sqla/test_auth.py
@@ -74,7 +74,7 @@ class TestFieldAccess:
             "/admin/post/create", cookies={"session": user_session}
         )
         assert response.status_code == 200
-        assert response.text.count('name="super_admin_only_field"') == expected_value
+        assert response.text.count(' name="super_admin_only_field"') == expected_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -114,7 +114,7 @@ class TestFieldAccess:
             "/admin/post/edit/1", cookies={"session": user_session}
         )
         assert response.status_code == 200
-        assert response.text.count('name="super_admin_only_field"') == expected_value
+        assert response.text.count(' name="super_admin_only_field"') == expected_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/sqla/test_sqla_and_pydantic.py
+++ b/tests/sqla/test_sqla_and_pydantic.py
@@ -130,15 +130,14 @@ async def test_create_validation_error(client: AsyncClient, session: Session):
     )
     assert response.status_code == 422
     assert (
-        '<div class="invalid-feedback">ensure this value has at least 10'
-        " characters</div>" in response.text
-        or '<div class="invalid-feedback">String should have at least 10'  # pydantic v2
-        " characters</div>" in response.text
+        'class="invalid-feedback">ensure this value has at least 10 characters'
+        in response.text
+        or 'class="invalid-feedback">String should have at least 10 characters'
+        in response.text  # pydantic v2
     )
     assert (
-        '<div class="invalid-feedback">none is not an allowed value</div>'
-        in response.text
-        or '<div class="invalid-feedback">Input should be a valid datetime</div>'  # pydantic v2
+        'class="invalid-feedback">none is not an allowed value' in response.text
+        or 'class="invalid-feedback">Input should be a valid datetime'  # pydantic v2
         in response.text
     )
 
@@ -180,16 +179,15 @@ async def test_edit_validation_error(client: AsyncClient, session: Session):
     )
     assert response.status_code == 422
     assert (
-        '<div class="invalid-feedback">ensure this value has at least 10'
-        " characters</div>" in response.text
-        or '<div class="invalid-feedback">String should have at least 10'  # pydantic v2
-        " characters</div>" in response.text
+        'class="invalid-feedback">ensure this value has at least 10 characters'
+        in response.text
+        or 'class="invalid-feedback">String should have at least 10 characters'
+        in response.text  # pydantic v2
     )
     assert (
-        '<div class="invalid-feedback">none is not an allowed value</div>'
-        in response.text
-        or '<div class="invalid-feedback">Input should be a valid datetime</div>'  # pydantic v2
-        in response.text
+        'class="invalid-feedback">none is not an allowed value' in response.text
+        or 'class="invalid-feedback">Input should be a valid datetime'
+        in response.text  # pydantic v2
     )
 
 

--- a/tests/sqla/test_sqlmodel.py
+++ b/tests/sqla/test_sqlmodel.py
@@ -94,15 +94,14 @@ async def test_create_validation_error(client: AsyncClient, session: Session):
     )
     assert response.status_code == 422
     assert (
-        '<div class="invalid-feedback">ensure this value has at least 10'
-        " characters</div>" in response.text
-        or '<div class="invalid-feedback">String should have at least 10'  # pydantic v2
-        " characters</div>" in response.text
+        'class="invalid-feedback">ensure this value has at least 10 characters'
+        in response.text
+        or 'class="invalid-feedback">String should have at least 10 characters'
+        in response.text  # pydantic v2
     )
     assert (
-        '<div class="invalid-feedback">none is not an allowed value</div>'
-        in response.text
-        or '<div class="invalid-feedback">Input should be a valid datetime</div>'  # pydantic v2
+        'class="invalid-feedback">none is not an allowed value' in response.text
+        or 'class="invalid-feedback">Input should be a valid datetime'  # pydantic v2
         in response.text
     )
 
@@ -145,15 +144,14 @@ async def test_edit_validation_error(client: AsyncClient, session: Session):
     )
     assert response.status_code == 422
     assert (
-        '<div class="invalid-feedback">ensure this value has at least 10'
-        " characters</div>" in response.text
-        or '<div class="invalid-feedback">String should have at least 10'  # pydantic v2
-        " characters</div>" in response.text
+        'class="invalid-feedback">ensure this value has at least 10 characters'
+        in response.text
+        or 'class="invalid-feedback">String should have at least 10 characters'
+        in response.text  # pydantic v2
     )
     assert (
-        '<div class="invalid-feedback">none is not an allowed value</div>'
-        in response.text
-        or '<div class="invalid-feedback">Input should be a valid datetime</div>'  # pydantic v2
+        'class="invalid-feedback">none is not an allowed value' in response.text
+        or 'class="invalid-feedback">Input should be a valid datetime'  # pydantic v2
         in response.text
     )
 

--- a/tests/sqla/test_sync_engine.py
+++ b/tests/sqla/test_sync_engine.py
@@ -459,9 +459,7 @@ async def test_file_validation_error(client: AsyncClient, fake_invalid_image):
         files={"image": ("image.png", fake_invalid_image, "image/png")},
     )
     assert response.status_code == 422
-    assert (
-        '<div class="invalid-feedback">Provide valid image file</div>' in response.text
-    )
+    assert 'class="invalid-feedback">Provide valid image file' in response.text
 
 
 async def test_create_with_empty_file(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -330,7 +330,7 @@ class TestFieldAccess:
     async def test_render_create(self, client, session, expected_value):
         response = await client.get("/admin/post/create", cookies={"session": session})
         assert response.status_code == 200
-        assert response.text.count('name="super_admin_only_field"') == expected_value
+        assert response.text.count(' name="super_admin_only_field"') == expected_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -367,7 +367,7 @@ class TestFieldAccess:
     async def test_render_edit(self, client, session, expected_value):
         response = await client.get("/admin/post/edit/1", cookies={"session": session})
         assert response.status_code == 200
-        assert response.text.count('name="super_admin_only_field"') == expected_value
+        assert response.text.count(' name="super_admin_only_field"') == expected_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR allows the use of Jinja2 templates in action forms, making it more flexible than plain HTML.

- Moved form initialization to HTML from JS to use Jinja2 for rendering.
- Separated modal windows for each action. This is also allows to use `select2` controls the same way it is done in editing/creation forms, without duplicating logic and without re-creating controls.
- Added a base form template that will be rendered if you pass form_fields to the rendering context.
- Separated the action and request_action logic so that these don't get mixed up in different parts of the code.
- Added an example of use and documented the feature.