### PR TITLE
Fix JSON serialization error for UUID primary keys when excluded from list

### DIFF
--- a/starlette_admin/contrib/sqla/view.py
+++ b/starlette_admin/contrib/sqla/view.py
@@ -1,16 +1,7 @@
 from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import anyio.to_thread
-from sqlalchemy import (
-    String,
-    and_,
-    cast,
-    func,
-    inspect,
-    or_,
-    select,
-    tuple_,
-)
+from sqlalchemy import String, and_, cast, func, inspect, or_, select, tuple_
 from sqlalchemy.exc import DBAPIError, NoInspectionAvailable, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import (
@@ -605,6 +596,10 @@ class ModelView(BaseModelView):
 
     async def get_pk_value(self, request: Request, obj: Any) -> Any:
         return await self.pk_field.parse_obj(request, obj)
+
+    async def get_serialized_pk_value(self, request: Request, obj: Any) -> Any:
+        value = await self.get_pk_value(request, obj)
+        return await self.pk_field.serialize_value(request, value, request.state.action)
 
     def handle_exception(self, exc: Exception) -> None:
         try:

--- a/starlette_admin/views.py
+++ b/starlette_admin/views.py
@@ -719,8 +719,8 @@ class BaseModelView(BaseView):
                     obj_serialized[field.name] = None
                 elif isinstance(field, HasOne):
                     if action == RequestAction.EDIT:
-                        obj_serialized[field.name] = await foreign_model.get_pk_value(
-                            request, value
+                        obj_serialized[field.name] = (
+                            await foreign_model.get_serialized_pk_value(request, value)
                         )
                     else:
                         obj_serialized[field.name] = await foreign_model.serialize(
@@ -729,7 +729,7 @@ class BaseModelView(BaseView):
                 else:
                     if action == RequestAction.EDIT:
                         obj_serialized[field.name] = [
-                            (await foreign_model.get_pk_value(request, obj))
+                            (await foreign_model.get_serialized_pk_value(request, obj))
                             for obj in value
                         ]
                     else:
@@ -750,11 +750,14 @@ class BaseModelView(BaseView):
                 "result": await self.select2_result(obj, request),
             }
         obj_meta["repr"] = await self.repr(obj, request)
+
+        # Make sure the primary key is always available
+        pk_attr = not_none(self.pk_attr)
+        if pk_attr not in obj_serialized:
+            pk_value = await self.get_serialized_pk_value(request, obj)
+            obj_serialized[pk_attr] = pk_value
+
         pk = await self.get_pk_value(request, obj)
-        obj_serialized[not_none(self.pk_attr)] = obj_serialized.get(
-            not_none(self.pk_attr),
-            pk,  # Make sure the primary key is always available
-        )
         route_name = request.app.state.ROUTE_NAME
         obj_meta["detailUrl"] = str(
             request.url_for(route_name + ":detail", identity=self.identity, pk=pk)
@@ -878,6 +881,23 @@ class BaseModelView(BaseView):
 
     async def get_pk_value(self, request: Request, obj: Any) -> Any:
         return getattr(obj, not_none(self.pk_attr))
+
+    async def get_serialized_pk_value(self, request: Request, obj: Any) -> Any:
+        """
+        Return serialized value of the primary key.
+
+        !!! note
+
+            The returned value should be JSON-serializable.
+
+        Parameters:
+            request: The request being processed
+            obj: object to get primary key of
+
+        Returns:
+            Any: Serialized value of a PK.
+        """
+        return await self.get_pk_value(request, obj)
 
     def _length_menu(self) -> Any:
         return [

--- a/tests/sqla/test_view_serialization.py
+++ b/tests/sqla/test_view_serialization.py
@@ -1,0 +1,92 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import Boolean, Column, ForeignKey, String
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, declarative_base, relationship
+from starlette.applications import Starlette
+from starlette_admin.contrib.sqla import Admin
+from starlette_admin.contrib.sqla.view import ModelView
+
+from tests.sqla.utils import Uuid, get_test_engine
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "user"
+
+    id = Column(Uuid, primary_key=True, default=uuid.uuid1, unique=True)
+    name = Column(String())
+    membership = relationship("Membership", back_populates="user", uselist=False)
+
+
+class Membership(Base):
+    __tablename__ = "membership"
+
+    id = Column(Uuid, primary_key=True, default=uuid.uuid1, unique=True)
+    is_active = Column(Boolean, default=True)
+
+    user_id = Column(Uuid, ForeignKey("user.id"), unique=True)
+    user = relationship("User", back_populates="membership")
+
+
+class UserView(ModelView):
+    fields = ["name", "membership"]
+
+
+@pytest.fixture
+def engine() -> Engine:
+    engine = get_test_engine()
+
+    Base.metadata.create_all(engine)
+
+    try:
+        yield engine
+
+    finally:
+        Base.metadata.drop_all(engine)
+
+
+@pytest.fixture
+def app(engine: Engine):
+    app = Starlette()
+
+    admin = Admin(engine)
+    admin.add_view(UserView(User))
+    admin.add_view(ModelView(Membership))
+    admin.mount_to(app)
+
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    async with AsyncClient(app=app, base_url="http://testserver") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_ensuring_pk(client: AsyncClient, engine: Engine):
+    """
+    Ensures PK is present in the serialized data and properly serialized as a string.
+    """
+    user_id = uuid.uuid1()
+    membership_id = uuid.uuid1()
+
+    user = User(id=user_id, name="Jack")
+    membership = Membership(id=membership_id, is_active=True, user=user)
+
+    with Session(engine) as session:
+        session.add(user)
+        session.add(membership)
+        session.commit()
+
+    response = await client.get("/admin/api/user")
+    data = response.json()
+
+    assert [(str(user_id), str(membership_id))] == [
+        (x["id"], x["membership"]["id"]) for x in data["items"]
+    ]

--- a/tests/sqla/test_view_serialization.py
+++ b/tests/sqla/test_view_serialization.py
@@ -19,7 +19,7 @@ class User(Base):
     __tablename__ = "user"
 
     id = Column(Uuid, primary_key=True, default=uuid.uuid1, unique=True)
-    name = Column(String())
+    name = Column(String(50))
     membership = relationship("Membership", back_populates="user", uselist=False)
 
 

--- a/tests/sqla/utils.py
+++ b/tests/sqla/utils.py
@@ -63,8 +63,6 @@ class Uuid(types.TypeDecorator):
         return value.hex
 
     def process_result_value(self, value, dialect):
-        if value is None:
-            return value
 
         if not isinstance(value, uuid.UUID):
             value = uuid.UUID(value)

--- a/tests/sqla/utils.py
+++ b/tests/sqla/utils.py
@@ -57,8 +57,6 @@ class Uuid(types.TypeDecorator):
         return mysql.CHAR(32) if dialect == "mysql" else types.CHAR(32)
 
     def process_bind_param(self, value, dialect):
-        if value is None:
-            return value
 
         return value.hex
 

--- a/tests/sqla/utils.py
+++ b/tests/sqla/utils.py
@@ -60,8 +60,6 @@ class Uuid(types.TypeDecorator):
         if value is None:
             return value
 
-        if not isinstance(value, uuid.UUID):
-            value = uuid.UUID(value)
 
         return value.hex
 

--- a/tests/sqla/utils.py
+++ b/tests/sqla/utils.py
@@ -60,7 +60,6 @@ class Uuid(types.TypeDecorator):
         if value is None:
             return value
 
-
         return value.hex
 
     def process_result_value(self, value, dialect):


### PR DESCRIPTION
Addresses #552 

When PK is not listed among fields it needs proper serialization in case it's not of a JSON-serializable type already (for example, UUID).

- `starlette_admin.BaseModelView` returns the PK value unchanged (for backwards compatibility)
- `starlette_admin.contrib.sqla.ModelView` uses PK field for proper serialization