### PR TITLE
Fix Deprecation Warnings for TemplateResponse and Jinja2Templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ env*
 .mypy_cache
 .vscode
 .idea
+.venv
 poetry.lock
 dist
 htmlcov

--- a/docs/user-guide/getting-started/index.md
+++ b/docs/user-guide/getting-started/index.md
@@ -132,7 +132,9 @@ from starlette_admin import CustomView
 class HomeView(CustomView):
     async def render(self, request: Request, templates: Jinja2Templates) -> Response:
         return templates.TemplateResponse(
-            "home.html", {"request": request, "latest_posts": ..., "top_users": ...}
+            request,
+            name="home.html", 
+            context={"latest_posts": ..., "top_users": ...},
         )
 
 

--- a/docs/user-guide/getting-started/index.md
+++ b/docs/user-guide/getting-started/index.md
@@ -133,7 +133,7 @@ class HomeView(CustomView):
     async def render(self, request: Request, templates: Jinja2Templates) -> Response:
         return templates.TemplateResponse(
             request,
-            name="home.html", 
+            name="home.html",
             context={"latest_posts": ..., "top_users": ...},
         )
 

--- a/starlette_admin/auth.py
+++ b/starlette_admin/auth.py
@@ -233,8 +233,9 @@ class AuthProvider(BaseAuthProvider):
         """Render the default login page for username & password authentication."""
         if request.method == "GET":
             return admin.templates.TemplateResponse(
-                "login.html",
-                {"request": request, "_is_login_path": True},
+                request=request,
+                name="login.html",
+                context={"_is_login_path": True},
             )
         form = await request.form()
         try:
@@ -251,14 +252,16 @@ class AuthProvider(BaseAuthProvider):
             )
         except FormValidationError as errors:
             return admin.templates.TemplateResponse(
-                "login.html",
-                {"request": request, "form_errors": errors, "_is_login_path": True},
+                request=request,
+                name="login.html",
+                context={"form_errors": errors, "_is_login_path": True},
                 status_code=HTTP_422_UNPROCESSABLE_ENTITY,
             )
         except LoginFailed as error:
             return admin.templates.TemplateResponse(
-                "login.html",
-                {"request": request, "error": error.msg, "_is_login_path": True},
+                request=request,
+                name="login.html",
+                context={"error": error.msg, "_is_login_path": True},
                 status_code=HTTP_400_BAD_REQUEST,
             )
 

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -2,7 +2,7 @@ import json
 from json import JSONDecodeError
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Type, Union
 
-from jinja2 import ChoiceLoader, FileSystemLoader, PackageLoader
+from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
 from starlette.applications import Starlette
 from starlette.datastructures import FormData
 from starlette.exceptions import HTTPException
@@ -190,13 +190,17 @@ class BaseAdmin:
             self._views.append(self.index_view)
 
     def _setup_templates(self) -> None:
-        templates = Jinja2Templates(self.templates_dir, extensions=["jinja2.ext.i18n"])
-        templates.env.loader = ChoiceLoader(
-            [
-                FileSystemLoader(self.templates_dir),
-                PackageLoader("starlette_admin", "templates"),
-            ]
+        env = Environment(
+            loader=ChoiceLoader(
+                [
+                    FileSystemLoader(self.templates_dir),
+                    PackageLoader("starlette_admin", "templates"),
+                ]
+            ),
+            extensions=["jinja2.ext.i18n"],
         )
+        templates = Jinja2Templates(env=env)
+
         # globals
         templates.env.globals["views"] = self._views
         templates.env.globals["app_title"] = self.title

--- a/starlette_admin/views.py
+++ b/starlette_admin/views.py
@@ -165,7 +165,9 @@ class CustomView(BaseView):
     async def render(self, request: Request, templates: Jinja2Templates) -> Response:
         """Default methods to render view. Override this methods to add your custom logic."""
         return templates.TemplateResponse(
-            self.template_path, {"request": request, "title": self.title(request)}
+            request=request,
+            name=self.template_path,
+            context={"title": self.title(request)},
         )
 
     def is_active(self, request: Request) -> bool:


### PR DESCRIPTION
Resolves https://github.com/jowilf/starlette-admin/issues/574

These warnings should no longer appear:

```
DeprecationWarning: Extra environment options are deprecated. Use a preconfigured jinja2.Environment instead.
```

```
DeprecationWarning: The `name` is not the first parameter anymore. The first parameter should be the `Request` instance.
 Replace `TemplateResponse(name, {"request": request})` by `TemplateResponse(request, name)`.
```

See:
- https://www.starlette.io/release-notes/#0290
- https://github.com/encode/starlette/pull/2191
- https://www.starlette.io/release-notes/#0280
- https://github.com/encode/starlette/pull/2159