### PR TITLE
feat(base): add redirect_slashes option to mount_to method

### DIFF
--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -524,7 +524,11 @@ class BaseAdmin:
             data[field.name] = await field.parse_form_data(request, form_data, action)
         return data
 
-    def mount_to(self, app: Starlette) -> None:
+    def mount_to(
+        self,
+        app: Starlette,
+        redirect_slashes: bool = True,
+    ) -> None:
         admin_app = Starlette(
             routes=self.routes,
             middleware=self.middlewares,
@@ -537,3 +541,4 @@ class BaseAdmin:
             app=admin_app,
             name=self.route_name,
         )
+        admin_app.router.redirect_slashes = redirect_slashes

--- a/starlette_admin/contrib/mongoengine/admin.py
+++ b/starlette_admin/contrib/mongoengine/admin.py
@@ -10,7 +10,7 @@ from starlette_admin.base import BaseAdmin
 
 
 class Admin(BaseAdmin):
-    def mount_to(self, app: Starlette) -> None:
+    def mount_to(self, app: Starlette, redirect_slashes: bool = True) -> None:
         self.routes.append(
             Route(
                 "/api/file/{db}/{col}/{pk}",
@@ -19,7 +19,7 @@ class Admin(BaseAdmin):
                 name="api:file",
             )
         )
-        super().mount_to(app)
+        super().mount_to(app, redirect_slashes)
 
 
 def _serve_file(request: Request) -> Response:

--- a/starlette_admin/contrib/sqla/admin.py
+++ b/starlette_admin/contrib/sqla/admin.py
@@ -57,7 +57,7 @@ class Admin(BaseAdmin):
         self.middlewares = [] if self.middlewares is None else list(self.middlewares)
         self.middlewares.insert(0, Middleware(DBSessionMiddleware, engine=engine))
 
-    def mount_to(self, app: Starlette) -> None:
+    def mount_to(self, app: Starlette, redirect_slashes: bool = True) -> None:
         try:
             """Automatically add route to serve sqlalchemy_file files"""
             __import__("sqlalchemy_file")
@@ -71,7 +71,7 @@ class Admin(BaseAdmin):
             )
         except ImportError:  # pragma: no cover
             pass
-        super().mount_to(app)
+        super().mount_to(app, redirect_slashes=redirect_slashes)
 
 
 def _serve_file(request: Request) -> Response:


### PR DESCRIPTION
Add optional redirect_slashes parameter to `BaseAdmin.mount_to()` and propagate it to SQLAlchemy Admin class. This allows users to control whether trailing slashes in URLs should be redirected, providing more flexibility in URL handling.

I'm working on a a litestar plugin to this awesome lib.
Inspired by https://github.com/peterschutt/sqladmin-litestar-plugin

Because of Starlette issue: https://github.com/encode/starlette/issues/869
We have to turn of redirect_slashes. In all of the nested Starlette apps.
Because admin_app is created deep in the Base class, it's impossible to do it without hacking the lib.
This PR makes it convenient and is backward compatible.
If you have suggestions how to do it better, let me know!