### PR TITLE
Update enum rendering to ensure 'selected' state is applied for data value of 0

### DIFF
--- a/starlette_admin/templates/forms/enum.html
+++ b/starlette_admin/templates/forms/enum.html
@@ -11,7 +11,7 @@
             <option></option>
         {% endif %}
         {% for value, label in field._get_choices(request) %}
-            <option value="{{ value }}" {{ 'selected' if (data and (value in (data if field.multiple else [data]))) else '' }}>{{ label }}
+            <option value="{{ value }}" {{ 'selected' if (data is not none and (value in (data if field.multiple else [data]))) else '' }}>{{ label }}
             </option>
         {% endfor %}
     </select>


### PR DESCRIPTION
This PR addresses issue #620, where the 'selected' state was not being set correctly for enums when the data value is 0. 