### PR TITLE
Reenable autoescaping in template rendering

### DIFF
--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2025-05-26
+
+### Fixed
+
+- Reenable autoescaping in template rendering by [@jowilf](https://github.com/jowilf)
+  in [#662](https://github.com/jowilf/starlette-admin/pull/662)
+
 ## [0.15.0] - 2025-05-21
 
 ### Breaking Changes

--- a/starlette_admin/__init__.py
+++ b/starlette_admin/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 from ._types import ExportType as ExportType
 from ._types import RequestAction as RequestAction

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -211,6 +211,7 @@ class BaseAdmin:
                 ]
             ),
             extensions=["jinja2.ext.i18n"],
+            autoescape=True,
         )
         templates = Jinja2Templates(env=env)
 


### PR DESCRIPTION
This PR #575 has disabled the Jinja2 autoescape. 
