### PR TITLE
Update templates to use relative routes (no host)

### DIFF
--- a/starlette_admin/auth.py
+++ b/starlette_admin/auth.py
@@ -11,7 +11,7 @@ from starlette.status import (
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
 from starlette_admin.exceptions import FormValidationError, LoginFailed
-from starlette_admin.helpers import wrap_endpoint_with_kwargs
+from starlette_admin.helpers import strip_host_filter, wrap_endpoint_with_kwargs
 from starlette_admin.i18n import lazy_gettext as _
 
 if TYPE_CHECKING:
@@ -270,7 +270,7 @@ class AuthProvider(BaseAuthProvider):
         return await self.logout(
             request,
             RedirectResponse(
-                request.url_for(admin.route_name + ":index"),
+                strip_host_filter(request.url_for(admin.route_name + ":index")),
                 status_code=HTTP_303_SEE_OTHER,
             ),
         )
@@ -363,7 +363,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         return RedirectResponse(
             "{url}?{query_params}".format(
-                url=request.url_for(request.app.state.ROUTE_NAME + ":login"),
+                url=strip_host_filter(
+                    request.url_for(request.app.state.ROUTE_NAME + ":login")
+                ),
                 query_params=urlencode({"next": str(request.url)}),
             ),
             status_code=HTTP_303_SEE_OTHER,

--- a/starlette_admin/contrib/mongoengine/fields.py
+++ b/starlette_admin/contrib/mongoengine/fields.py
@@ -6,6 +6,7 @@ from starlette.requests import Request
 from starlette_admin._types import RequestAction
 from starlette_admin.fields import FileField as BaseFileField
 from starlette_admin.fields import ImageField as BaseImageField
+from starlette_admin.helpers import strip_host_filter
 
 
 @dataclass
@@ -38,7 +39,7 @@ def _serialize_file_field(
         return {
             "filename": getattr(value, "filename", "unamed"),
             "content_type": getattr(value, "content_type", "application/octet-stream"),
-            "url": str(
+            "url": strip_host_filter(
                 request.url_for(
                     request.app.state.ROUTE_NAME + ":api:file",
                     db=value.db_alias,

--- a/starlette_admin/contrib/sqla/fields.py
+++ b/starlette_admin/contrib/sqla/fields.py
@@ -7,6 +7,7 @@ from starlette_admin.contrib.sqla.exceptions import NotSupportedValue
 from starlette_admin.fields import FileField as BaseFileField
 from starlette_admin.fields import ImageField as BaseImageField
 from starlette_admin.fields import StringField
+from starlette_admin.helpers import strip_host_filter
 from starlette_admin.tools import iterencode
 
 
@@ -94,7 +95,7 @@ def _serialize_sqlalchemy_file_library(
                 {
                     "content_type": item["content_type"],
                     "filename": item["filename"],
-                    "url": str(
+                    "url": strip_host_filter(
                         request.url_for(
                             request.app.state.ROUTE_NAME + ":api:file",
                             storage=storage,

--- a/starlette_admin/fields.py
+++ b/starlette_admin/fields.py
@@ -22,7 +22,12 @@ from typing import (
 from starlette.datastructures import FormData, UploadFile
 from starlette.requests import Request
 from starlette_admin._types import RequestAction
-from starlette_admin.helpers import extract_fields, html_params, is_empty_file
+from starlette_admin.helpers import (
+    extract_fields,
+    html_params,
+    is_empty_file,
+    strip_host_filter,
+)
 from starlette_admin.i18n import (
     format_date,
     format_datetime,
@@ -440,7 +445,7 @@ class TagsField(BaseField):
     ) -> List[str]:
         if action.is_form():
             return [
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path="css/select2.min.css",
@@ -452,7 +457,7 @@ class TagsField(BaseField):
     def additional_js_links(self, request: Request, action: RequestAction) -> List[str]:
         if action.is_form():
             return [
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path="js/vendor/select2.min.js",
@@ -604,7 +609,7 @@ class EnumField(StringField):
     ) -> List[str]:
         if self.select2 and action.is_form():
             return [
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path="css/select2.min.css",
@@ -616,7 +621,7 @@ class EnumField(StringField):
     def additional_js_links(self, request: Request, action: RequestAction) -> List[str]:
         if self.select2 and action.is_form():
             return [
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path="js/vendor/select2.min.js",
@@ -756,7 +761,7 @@ class DateTimeField(NumberField):
     ) -> List[str]:
         if action.is_form():
             return [
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path="css/flatpickr.min.css",
@@ -767,7 +772,7 @@ class DateTimeField(NumberField):
 
     def additional_js_links(self, request: Request, action: RequestAction) -> List[str]:
         _links = [
-            str(
+            strip_host_filter(
                 request.url_for(
                     f"{request.app.state.ROUTE_NAME}:statics",
                     path="js/vendor/flatpickr.min.js",
@@ -776,7 +781,7 @@ class DateTimeField(NumberField):
         ]
         if get_locale() != "en":
             _links.append(
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path=f"i18n/flatpickr/{get_locale()}.js",
@@ -913,7 +918,7 @@ class JSONField(BaseField):
     ) -> List[str]:
         if action.is_form():
             return [
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path="css/jsoneditor.min.css",
@@ -925,7 +930,7 @@ class JSONField(BaseField):
     def additional_js_links(self, request: Request, action: RequestAction) -> List[str]:
         if action.is_form():
             return [
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path="js/vendor/jsoneditor.min.js",
@@ -1061,7 +1066,7 @@ class RelationField(BaseField):
     ) -> List[str]:
         if action.is_form():
             return [
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path="css/select2.min.css",
@@ -1073,7 +1078,7 @@ class RelationField(BaseField):
     def additional_js_links(self, request: Request, action: RequestAction) -> List[str]:
         if action.is_form():
             return [
-                str(
+                strip_host_filter(
                     request.url_for(
                         f"{request.app.state.ROUTE_NAME}:statics",
                         path="js/vendor/select2.min.js",

--- a/starlette_admin/helpers.py
+++ b/starlette_admin/helpers.py
@@ -12,8 +12,10 @@ from typing import (
     TypeVar,
     Union,
 )
+from urllib.parse import urlsplit
 
 from markupsafe import escape
+from starlette.datastructures import URL
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette_admin._types import RequestAction
@@ -130,6 +132,11 @@ def wrap_endpoint_with_kwargs(
         return await endpoint(request=request, **kwargs)
 
     return wrapper
+
+
+def strip_host_filter(url: str | URL) -> str:
+    parsed = urlsplit(str(url))
+    return parsed.path + ("?" + parsed.query if parsed.query else "")
 
 
 T = TypeVar("T")

--- a/starlette_admin/templates/base.html
+++ b/starlette_admin/templates/base.html
@@ -9,8 +9,8 @@
     {% endif %}
     {% block head_meta %}{% endblock %}
     {% block title %}<title>{{ title or app_title }}</title>{% endblock %}
-    <link rel="stylesheet" href="{{ url_for(__name__ ~ ':statics', path='css/tabler.min-1.1.0.css') }}">
-    <link rel="stylesheet" href="{{ url_for(__name__ ~ ':statics', path='css/fontawesome.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for(__name__ ~ ':statics', path='css/tabler.min-1.1.0.css') | strip_host }}">
+    <link rel="stylesheet" href="{{ url_for(__name__ ~ ':statics', path='css/fontawesome.min.css') | strip_host }}">
     <style>
         @import url('https://rsms.me/inter/inter.css');
 
@@ -33,10 +33,10 @@
 <body>
 {% block body %}{% endblock %}
 {% block modal %}{% endblock %}
-<script type="text/javascript" src="{{ url_for(__name__ ~ ':statics', path='js/vendor/jquery.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for(__name__ ~ ':statics', path='js/vendor/js.cookie.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for(__name__ ~ ':statics', path='js/vendor/jquery.min.js') | strip_host }}"></script>
+<script type="text/javascript" src="{{ url_for(__name__ ~ ':statics', path='js/vendor/js.cookie.min.js') | strip_host }}"></script>
 <script type="text/javascript"
-        src="{{ url_for(__name__ ~ ':statics', path='js/vendor/tabler.min-1.1.0.js') }}"></script>
+        src="{{ url_for(__name__ ~ ':statics', path='js/vendor/tabler.min-1.1.0.js') | strip_host }}"></script>
 {% block script %}{% endblock %}
 <script>
     $(function () {

--- a/starlette_admin/templates/create.html
+++ b/starlette_admin/templates/create.html
@@ -4,10 +4,10 @@
         <h1>{{ model.label }}</h1>
         <ol class="breadcrumb">
             <li class="breadcrumb-item">
-                <a href="{{ url_for(__name__ ~ ':index') }}">{{ _("Admin") }}</a>
+                <a href="{{ url_for(__name__ ~ ':index')  | strip_host }}">{{ _("Admin") }}</a>
             </li>
             <li class="breadcrumb-item">
-                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) }}">{{ model.label }}</a>
+                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) | strip_host }}">{{ model.label }}</a>
             </li>
             <li class="breadcrumb-item active">{{ _("Create") }}</li>
         </ol>
@@ -18,7 +18,7 @@
         <div class="row">
             <div class="col-12">
                 <div class="card">
-                    <form action="{{ request.url | safe }}" method="POST" enctype="multipart/form-data">
+                    <form action="{{ request.url | strip_host | safe }}" method="POST" enctype="multipart/form-data">
                         <div class="card-header">
                             <div class="container-fluid">
                                 <div class="d-flex justify-content-between align-items-center">
@@ -40,7 +40,7 @@
                         </div>
                         <div class="card-footer text-black">
                             <div class="btn-list ms-auto justify-content-end">
-                                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) }}"
+                                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) | strip_host }}"
                                    class="btn btn-danger">{{ _("Cancel") }}</a>
                                 <button type="submit" name="_add_another"
                                         class="btn">{{ _("Save and add another") }}</button>
@@ -68,7 +68,7 @@
 {% endblock %}
 {% block script %}
     {{ super() }}
-    <script type="text/javascript" src="{{ url_for(__name__ ~ ':statics', path='js/form.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for(__name__ ~ ':statics', path='js/form.js') | strip_host }}"></script>
     {% for link in model._additional_js_links(request, "CREATE" | ra) %}
         <script type="text/javascript" src="{{ link }}"></script>
     {% endfor %}

--- a/starlette_admin/templates/detail.html
+++ b/starlette_admin/templates/detail.html
@@ -5,10 +5,10 @@
         <h1>{{ model.label }}</h1>
         <ol class="breadcrumb">
             <li class="breadcrumb-item">
-                <a href="{{ url_for(__name__ ~ ':index') }}">{{ _("Admin") }}</a>
+                <a href="{{ url_for(__name__ ~ ':index') | strip_host }}">{{ _("Admin") }}</a>
             </li>
             <li class="breadcrumb-item">
-                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) }}">{{ model.label }}</a>
+                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) | strip_host }}">{{ model.label }}</a>
             </li>
             <li class="breadcrumb-item active">{{ _("Detail") }}</li>
         </ol>
@@ -105,18 +105,18 @@
 {% block script %}
     {{ super() }}
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/alerts.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/alerts.js') | strip_host }}"></script>
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/actions.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/actions.js') | strip_host }}"></script>
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/utils.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/utils.js') | strip_host }}"></script>
     {% for link in model._additional_js_links(request, "DETAIL" | ra) %}
         <script type="text/javascript" src="{{ link }}"></script>
     {% endfor %}
     <script>
         var actionManager = new ActionManager(
             "", // not necessary
-            "{{ url_for(__name__ ~ ':row-action', identity=model.identity)  | safe }}",
+            "{{ url_for(__name__ ~ ':row-action', identity=model.identity)  | strip_host | safe }}",
             function (query, element) {
                 // appendQueryParams
                 query.append(
@@ -128,7 +128,7 @@
                 // onSuccess
                 localStorage.successAlert = msg;
                 if (actionName === 'delete') // special case for delete row action
-                    window.location.replace("{{ url_for(__name__ ~ ':list', identity=model.identity)  | safe }}")
+                    window.location.replace("{{ url_for(__name__ ~ ':list', identity=model.identity) | strip_host | safe }}")
                 else
                     window.location.reload()
             },

--- a/starlette_admin/templates/displays/relation.html
+++ b/starlette_admin/templates/displays/relation.html
@@ -2,6 +2,6 @@
     {% for v in (data if field.multiple else [data]) %}
         {% set foreign_model = (field.identity | to_model) %}
         <a class="m-1 py-1 px-2 badge bg-blue-lt lead"
-           href="{{ url_for(__name__ ~ ':detail', identity=foreign_model.identity,pk=v[foreign_model.pk_attr]) }}">{{ v["_meta"]["repr"] }}</a>
+           href="{{ url_for(__name__ ~ ':detail', identity=foreign_model.identity, pk=v[foreign_model.pk_attr]) | strip_host }}">{{ v["_meta"]["repr"] }}</a>
     {% endfor %}
 </div>

--- a/starlette_admin/templates/edit.html
+++ b/starlette_admin/templates/edit.html
@@ -4,10 +4,10 @@
         <h1>{{ model.label }}</h1>
         <ol class="breadcrumb">
             <li class="breadcrumb-item">
-                <a href="{{ url_for(__name__ ~ ':index') }}">{{ _("Admin") }}</a>
+                <a href="{{ url_for(__name__ ~ ':index') | strip_host }}">{{ _("Admin") }}</a>
             </li>
             <li class="breadcrumb-item">
-                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) }}">{{ model.label }}</a>
+                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) | strip_host }}">{{ model.label }}</a>
             </li>
             <li class="breadcrumb-item active">{{ _("Edit") }}</li>
         </ol>
@@ -18,7 +18,7 @@
         <div class="row">
             <div class="col-12">
                 <div class="card">
-                    <form action="{{ request.url | safe }}"
+                    <form action="{{ request.url | strip_host | safe }}"
                           method="POST"
                           enctype="multipart/form-data">
                         <div class="card-header">
@@ -42,7 +42,7 @@
                         </div>
                         <div class="card-footer text-black">
                             <div class="btn-list ms-auto justify-content-end">
-                                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) }}"
+                                <a href="{{ url_for(__name__ ~ ':list', identity=model.identity) | strip_host }}"
                                    class="btn btn-danger">{{ _("Cancel") }}</a>
                                 <button type="submit" name="_add_another"
                                         class="btn">{{ _("Save and add another") }}</button>
@@ -71,8 +71,8 @@
 {% block script %}
     {{ super() }}
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/form.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/form.js') | strip_host }}"></script>
     {% for link in model._additional_js_links(request, "EDIT" | ra) %}
-        <script type="text/javascript" src="{{ link }}"></script>
+        <script type="text/javascript" src="{{ link | strip_host}}"></script>
     {% endfor %}
 {% endblock %}

--- a/starlette_admin/templates/error.html
+++ b/starlette_admin/templates/error.html
@@ -7,7 +7,7 @@
         <p class="empty-title">{{ _("Oops… You just found an error page") }}</p>
         <p class="empty-subtitle text-muted">{{ exc.detail }}</p>
         <div class="empty-action">
-            <a class="btn btn-primary" href="{{ url_for(__name__ ~ ':index') }}">
+            <a class="btn btn-primary" href="{{ url_for(__name__ ~ ':index')  | strip_host }}">
                 <svg class="icon"
                      fill="none"
                      height="24"

--- a/starlette_admin/templates/forms/relation.html
+++ b/starlette_admin/templates/forms/relation.html
@@ -6,7 +6,7 @@
             id="{{ field.id }}"
             name="{{ field.id }}"
             class="form-control {{ 'field-has-one' if not field.many else 'field-has-many' }} {% if error %}is-invalid{% endif %}"
-            data-url="{{ url_for(__name__ ~ ':api', identity=foreign_model.identity) }}"
+            data-url="{{ url_for(__name__ ~ ':api', identity=foreign_model.identity) | strip_host }}"
             data-pk="{{ fpk }}"
             {% if data %}data-initial="{{ (data if field.multiple else [data]) |tojson |forceescape }}" {% endif %}
             {% if field.multiple %}multiple{% endif %}>

--- a/starlette_admin/templates/layout.html
+++ b/starlette_admin/templates/layout.html
@@ -20,7 +20,7 @@
                         <span class="navbar-toggler-icon"></span>
                     </button>
                     <h1 class="navbar-brand navbar-brand-autodark">
-                        <a class="brand-link" href="{{ url_for(__name__ ~ ':index') }}">
+                        <a class="brand-link" href="{{ url_for(__name__ ~ ':index') | strip_host }}">
                             {% if logo_url %}
                                 <img src="{{ logo_url }}"
                                      class="navbar-logo"/>
@@ -92,7 +92,7 @@
                                         </div>
                                     </a>
                                     <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
-                                        <a href="{{ request.url_for(__name__ ~ ':logout') }}"
+                                        <a href="{{ request.url_for(__name__ ~ ':logout') | strip_host }}"
                                            class="dropdown-item">{{ _("Logout") }}</a>
                                     </div>
                                 </div>
@@ -113,7 +113,7 @@
                                 {% endif %}
                             {% endfor %}
                             {% if is_auth_enabled and current_user is none %}
-                                <a href="{{ request.url_for(__name__ ~ ':logout') }}"
+                                <a href="{{ request.url_for(__name__ ~ ':logout') | strip_host }}"
                                    class="btn btn-light mx-1 mt-2">
                                     <i class="fa fa-sign-out"></i>
                                     <span class="ms-2">{{ _("Logout") }}</span>
@@ -201,7 +201,7 @@
                                         </div>
                                     </a>
                                     <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
-                                        <a href="{{ request.url_for(__name__ ~ ':logout') }}"
+                                        <a href="{{ request.url_for(__name__ ~ ':logout') | strip_host }}"
                                            class="dropdown-item">{{ _("Logout") }}</a>
                                     </div>
                                 </div>

--- a/starlette_admin/templates/list.html
+++ b/starlette_admin/templates/list.html
@@ -4,7 +4,7 @@
         <h1>{{ model.label }}</h1>
         <ol class="breadcrumb">
             <li class="breadcrumb-item">
-                <a href="{{ url_for(__name__ ~ ':index') }}">{{ _("Admin") }}</a>
+                <a href="{{ url_for(__name__ ~ ':index') | strip_host }}">{{ _("Admin") }}</a>
             </li>
             <li class="breadcrumb-item active">{{ model.label }}</li>
         </ol>
@@ -28,7 +28,7 @@
                                 {% include "actions.html" %}
 
                                 {% if model.can_create(request) %}
-                                    <a href="{{ url_for(__name__ ~ ':create', identity=model.identity) }}"
+                                    <a href="{{ url_for(__name__ ~ ':create', identity=model.identity) | strip_host }}"
                                        class="btn btn-primary btn-block ms-2">
                                         <i class="fa-solid fa-plus me-2"></i>
                                         {{ _("New %(name)s", name=model.name ) }}
@@ -88,9 +88,9 @@
 {% block head_css %}
     {{ super() }}
     <link rel="stylesheet"
-          href="{{ url_for(__name__ ~ ':statics', path='css/dt.min.css') }}"/>
+          href="{{ url_for(__name__ ~ ':statics', path='css/dt.min.css') | strip_host }}"/>
     <link rel="stylesheet"
-          href="{{ url_for(__name__ ~ ':statics', path='css/dt.checkboxes.css') }}"/>
+          href="{{ url_for(__name__ ~ ':statics', path='css/dt.checkboxes.css')  | strip_host }}"/>
     {% for link in model._additional_css_links(request, "LIST" | ra) %}
         <link rel="stylesheet" href="{{ link }}">
     {% endfor %}
@@ -123,38 +123,38 @@
 {% block script %}
     {{ super() }}
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/vendor/moment.min.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/vendor/moment.min.js') | strip_host }}"></script>
     {% if get_locale() != 'en' %}
         <script type="text/javascript"
-                src="{{ url_for(__name__ ~ ':statics', path='i18n/momentjs/' ~ get_locale() ~ '.js') }}"></script>
+                src="{{ url_for(__name__ ~ ':statics', path='i18n/momentjs/' ~ get_locale() ~ '.js') | strip_host }}"></script>
     {% endif %}
     {% if 'pdf' in model.export_types %}
         <script type="text/javascript"
-                src="{{ url_for(__name__ ~ ':statics', path='js/vendor/pdfmake.min.js') }}"></script>
+                src="{{ url_for(__name__ ~ ':statics', path='js/vendor/pdfmake.min.js') | strip_host }}"></script>
         <script type="text/javascript"
-                src="{{ url_for(__name__ ~ ':statics', path='js/vendor/vfs_fonts.js') }}"></script>
+                src="{{ url_for(__name__ ~ ':statics', path='js/vendor/vfs_fonts.js') | strip_host }}"></script>
     {% endif %}
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/vendor/dt.min.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/vendor/dt.min.js') | strip_host }}"></script>
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/vendor/dt.checkboxes.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/vendor/dt.checkboxes.js') | strip_host }}"></script>
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/vendor/dt.searchHighlight.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/vendor/dt.searchHighlight.js') | strip_host }}"></script>
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/utils.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/utils.js') | strip_host }}"></script>
     <script>var model = {{__js_model__ | tojson | safe}};</script>
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/render.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/render.js') | strip_host }}"></script>
     {% if custom_render_js(request) %}
-        <script type="text/javascript" src="{{ custom_render_js(request) }}"></script>
+        <script type="text/javascript" src="{{ custom_render_js(request) | strip_host }}"></script>
     {% endif %}
     {% for link in model._additional_js_links(request, "LIST" | ra) %}
         <script type="text/javascript" src="{{ link }}"></script>
     {% endfor %}
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/alerts.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/alerts.js') | strip_host }}"></script>
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/actions.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/actions.js') | strip_host }}"></script>
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/list.js') }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/list.js') | strip_host }}"></script>
 {% endblock %}

--- a/starlette_admin/templates/login.html
+++ b/starlette_admin/templates/login.html
@@ -11,7 +11,7 @@
                 </a>
             </div>
         {% endif %}
-        <form class="card card-md" action="{{ request.url }}" method="POST">
+        <form class="card card-md" action="{{ request.url | strip_host }}" method="POST">
             <div class="card-body">
                 <h2 class="card-title text-center mb-4">{{ _("Login to your account") }}</h2>
                 {% if error %}

--- a/starlette_admin/templates/macros/views.html
+++ b/starlette_admin/templates/macros/views.html
@@ -13,7 +13,7 @@
 {% macro custom_link(view) -%}
     <li class="nav-item">
         <a class="nav-link {% if view.is_active(request) %}active fw-bold{% endif %}"
-           href="{{ url_for(__name__,path=view.path) }}">
+           href="{{ url_for(__name__,path=view.path) | strip_host }}">
             {% if view.icon %}
                 <span class="nav-link-icon d-md-none d-lg-inline-block">
                     <i class="{{ view.icon }}"></i>
@@ -26,7 +26,7 @@
 {% macro model_link(view) -%}
     <li class="nav-item">
         <a class="nav-link {% if view.is_active(request) %}active fw-bold{% endif %}"
-           href="{{ url_for(__name__ ~ ':list', identity=view.identity) }}">
+           href="{{ url_for(__name__ ~ ':list', identity=view.identity) | strip_host }}">
             {% if view.icon %}
                 <span class="nav-link-icon d-md-none d-lg-inline-block">
                     <i class="{{ view.icon }}"></i>
@@ -56,9 +56,9 @@
                         {% if (item| is_link) %}
                             <a href="{{ item.url }}" class="dropdown-item" target="{{ item.target }}">{{ item.label }}</a>
                         {% elif (item| is_custom_view) and item.add_to_menu %}
-                            <a href="{{ url_for(__name__ ,path=item.path) }}" class="dropdown-item{% if item.is_active(request) %} active fw-bold{% endif %}">{{ item.label }}</a>
+                            <a href="{{ url_for(__name__ ,path=item.path)  | strip_host }}" class="dropdown-item{% if item.is_active(request) %} active fw-bold{% endif %}">{{ item.label }}</a>
                         {% elif (item| is_model) %}
-                            <a href="{{ url_for(__name__ ~ ':list', identity=item.identity) }}" class="dropdown-item{% if item.is_active(request) %} active fw-bold {% endif %}">{{ item.label }}</a>
+                            <a href="{{ url_for(__name__ ~ ':list', identity=item.identity) | strip_host }}" class="dropdown-item{% if item.is_active(request) %} active fw-bold {% endif %}">{{ item.label }}</a>
                         {% elif (item | is_dropdown) %}
                             {{ dropdown_link(item) }}
                         {% endif %}

--- a/starlette_admin/views.py
+++ b/starlette_admin/views.py
@@ -29,7 +29,7 @@ from starlette_admin.fields import (
     HasOne,
     RelationField,
 )
-from starlette_admin.helpers import extract_fields, not_none
+from starlette_admin.helpers import extract_fields, not_none, strip_host_filter
 from starlette_admin.i18n import get_locale, gettext, ngettext
 from starlette_admin.i18n import lazy_gettext as _
 
@@ -481,7 +481,7 @@ class BaseModelView(BaseView):
     )
     def row_action_1_view(self, request: Request, pk: Any) -> str:
         route_name = request.app.state.ROUTE_NAME
-        return str(
+        return strip_host_filter(
             request.url_for(route_name + ":detail", identity=self.identity, pk=pk)
         )
 
@@ -493,7 +493,9 @@ class BaseModelView(BaseView):
     )
     def row_action_2_edit(self, request: Request, pk: Any) -> str:
         route_name = request.app.state.ROUTE_NAME
-        return str(request.url_for(route_name + ":edit", identity=self.identity, pk=pk))
+        return strip_host_filter(
+            request.url_for(route_name + ":edit", identity=self.identity, pk=pk)
+        )
 
     @row_action(
         name="delete",
@@ -761,7 +763,7 @@ class BaseModelView(BaseView):
 
         pk = await self.get_pk_value(request, obj)
         route_name = request.app.state.ROUTE_NAME
-        obj_meta["detailUrl"] = str(
+        obj_meta["detailUrl"] = strip_host_filter(
             request.url_for(route_name + ":detail", identity=self.identity, pk=pk)
         )
         obj_serialized["_meta"] = obj_meta
@@ -968,17 +970,26 @@ class BaseModelView(BaseView):
             "fields": [f.dict() for f in self.get_fields_list(request)],
             "pk": self.pk_attr,
             "locale": locale,
-            "apiUrl": request.url_for(
-                f"{request.app.state.ROUTE_NAME}:api", identity=self.identity
+            "apiUrl": strip_host_filter(
+                request.url_for(
+                    f"{request.app.state.ROUTE_NAME}:api", identity=self.identity
+                )
             ),
-            "actionUrl": request.url_for(
-                f"{request.app.state.ROUTE_NAME}:action", identity=self.identity
+            "actionUrl": strip_host_filter(
+                request.url_for(
+                    f"{request.app.state.ROUTE_NAME}:action", identity=self.identity
+                )
             ),
-            "rowActionUrl": request.url_for(
-                f"{request.app.state.ROUTE_NAME}:row-action", identity=self.identity
+            "rowActionUrl": strip_host_filter(
+                request.url_for(
+                    f"{request.app.state.ROUTE_NAME}:row-action", identity=self.identity
+                )
             ),
-            "dt_i18n_url": request.url_for(
-                f"{request.app.state.ROUTE_NAME}:statics", path=f"i18n/dt/{locale}.json"
+            "dt_i18n_url": strip_host_filter(
+                request.url_for(
+                    f"{request.app.state.ROUTE_NAME}:statics",
+                    path=f"i18n/dt/{locale}.json",
+                )
             ),
             "datatablesOptions": self.datatables_options,
         }

--- a/tests/mongoengine/test_view.py
+++ b/tests/mongoengine/test_view.py
@@ -321,7 +321,7 @@ class TestMongoBasic:
         response = client.get(f"/admin/product/detail/{product.id}")
         assert response.status_code == 200
         assert (
-            f'src="http://testserver/admin/api/file/default/images/{product.image.grid_id}"'
+            f'src="/admin/api/file/default/images/{product.image.grid_id}"'
             in response.text
         )
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -113,7 +113,7 @@ class TestAuth:
         assert response.status_code == 303
         assert (
             response.headers.get("location")
-            == "http://testserver/admin/login?next=http%3A%2F%2Ftestserver%2Fadmin%2F"
+            == "/admin/login?next=http%3A%2F%2Ftestserver%2Fadmin%2F"
         )
 
     @pytest.mark.asyncio
@@ -144,7 +144,7 @@ class TestAuth:
         assert response.status_code == 303
         assert (
             response.headers.get("location")
-            == "http://testserver/admin/custom-login?next=http%3A%2F%2Ftestserver%2Fadmin%2F"
+            == "/admin/custom-login?next=http%3A%2F%2Ftestserver%2Fadmin%2F"
         )
 
     def test_deprecated_allow_paths(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -196,7 +196,7 @@ class TestViews:
             assert value["_meta"]["select2"]["selection"] is not None
             assert value["_meta"]["select2"]["result"] is not None
         assert data["items"][0]["_meta"] == {
-            "detailUrl": "http://testserver/admin/user/detail/1",
+            "detailUrl": "/admin/user/detail/1",
             "repr": "John Doe",
             "select2": {
                 "selection": "<span>John Doe</span>",
@@ -217,7 +217,7 @@ class TestViews:
             assert value["_meta"]["select2"]["selection"] is not None
         title = "Dave wasn't exactly sure how he had ended up"
         assert data["items"][0]["_meta"] == {
-            "detailUrl": "http://testserver/admin/post/detail/1",
+            "detailUrl": "/admin/post/detail/1",
             "repr": title,
             "select2": {
                 "selection": f"<span>{title}</span>",
@@ -241,7 +241,7 @@ class TestViews:
             "/admin/post/create", data=dummy_data, follow_redirects=False
         )
         assert response.status_code == 303
-        assert response.headers.get("location") == "http://testserver/admin/post/list"
+        assert response.headers.get("location") == "/admin/post/list"
         assert len(PostView.db) == 6
         assert PostView.db[6] == Post(id=6, **dummy_data)
 
@@ -251,7 +251,7 @@ class TestViews:
             follow_redirects=False,
         )
         assert response.status_code == 303
-        assert response.headers.get("location") == "http://testserver/admin/post/edit/7"
+        assert response.headers.get("location") == "/admin/post/edit/7"
 
         response = client.post(
             "/admin/post/create",
@@ -259,7 +259,7 @@ class TestViews:
             follow_redirects=False,
         )
         assert response.status_code == 303
-        assert response.headers.get("location") == "http://testserver/admin/post/create"
+        assert response.headers.get("location") == "/admin/post/create"
 
     def test_model_view_edit(self):
         admin = BaseAdmin()
@@ -277,7 +277,7 @@ class TestViews:
             "/admin/post/edit/5", data=dummy_data, follow_redirects=False
         )
         assert response.status_code == 303
-        assert response.headers.get("location") == "http://testserver/admin/post/list"
+        assert response.headers.get("location") == "/admin/post/list"
         assert len(PostView.db) == 5
         assert PostView.db[5] == Post(id=5, **dummy_data)
 
@@ -287,7 +287,7 @@ class TestViews:
             follow_redirects=False,
         )
         assert response.status_code == 303
-        assert response.headers.get("location") == "http://testserver/admin/post/edit/5"
+        assert response.headers.get("location") == "/admin/post/edit/5"
 
         response = client.post(
             "/admin/post/edit/5",
@@ -295,7 +295,7 @@ class TestViews:
             follow_redirects=False,
         )
         assert response.status_code == 303
-        assert response.headers.get("location") == "http://testserver/admin/post/create"
+        assert response.headers.get("location") == "/admin/post/create"
 
     def test_model_view_create_validation_error(self):
         class PostViewWithRestrictedTitle(PostView):
@@ -487,15 +487,13 @@ class TestViews:
         assert response.text.count('<span class="nav-link-title">') == 2
         assert (
             response.text.count(
-                '<a href="http://testserver/admin/user/list"'
-                ' class="dropdown-item">Users</a>'
+                '<a href="/admin/user/list"' ' class="dropdown-item">Users</a>'
             )
             == 1
         )
         assert (
             response.text.count(
-                '<a href="http://testserver/admin/report"'
-                ' class="dropdown-item">Report</a>'
+                '<a href="/admin/report"' ' class="dropdown-item">Report</a>'
             )
             == 1
         )


### PR DESCRIPTION
Hello,

Was running starlette-admin from behind Nginx in Kubernetes. 
HTTPS is configured on NGINX, and the backing application where starlette-admin is running uses HTTP.

Ran into issue #400 where starlette-admin was serving HTTP content, `This request has been blocked; the content must be served over HTTPS.`. 

I think a solution to this is to use relative routes, by removing the host and protocol portion of all links used. E.g. instead of `http://example.com/statics/css/tabler.min.css`, use `/statics/css/tabler.min.css`. 

I did this in the PR by using the `strip_host_filter` function. I use this in the Jinja templates and in some areas of the python code.

Edited testcases that assert on absolute routes in 6a2c435. 

Best,
Alex