### PR TITLE
fix(beanie): always taking field from document even when given from model view

### DIFF
--- a/starlette_admin/contrib/beanie/converters.py
+++ b/starlette_admin/contrib/beanie/converters.py
@@ -19,6 +19,7 @@ from starlette_admin.contrib.beanie.helpers import (
     is_link_type,
     is_list_of_links_type,
     isvalid_field,
+    resolve_expression_field_name,
 )
 from starlette_admin.converters import StandardModelConverter, converts
 from starlette_admin.fields import (
@@ -136,7 +137,11 @@ class BeanieModelConverter(StandardModelConverter):
             if isinstance(value, BaseField):
                 converted_fields.append(value)
             else:
-                field = str(value) if isinstance(value, ExpressionField) else value
+                field = (
+                    resolve_expression_field_name(value)
+                    if isinstance(value, ExpressionField)
+                    else value
+                )
                 if not isvalid_field(model, field):
                     raise ValueError(f"Invalid field: {field}")
                 field_type = self.get_type_beanie(model.model_fields, value)

--- a/starlette_admin/contrib/beanie/helpers.py
+++ b/starlette_admin/contrib/beanie/helpers.py
@@ -79,15 +79,18 @@ def isvalid_field(document: Type[Document], field: str) -> bool:
         return False
 
 
-def normalize_field_list(
-    field_list: List[Union[str, ExpressionField]], document: Type[Document]
-) -> List[str]:
-
+def normalize_field_list(field_list: List[Union[str, ExpressionField]]) -> List[str]:
     converted_field_list = []
     for field in field_list:
-        field_name = str(field) if isinstance(field, ExpressionField) else field
-        if not isvalid_field(document, field_name):
-            raise ValueError(f"Invalid field: {field_name}")
+        if isinstance(field, ExpressionField):
+            field_name = str(field)
+        elif isinstance(field, str):
+            field_name = field
+        else:
+            raise ValueError(
+                f"Expected str or ExpressionField, got {type(field).__name__}"
+            )
+
         converted_field_list.append(field_name)
     return converted_field_list
 

--- a/starlette_admin/contrib/beanie/helpers.py
+++ b/starlette_admin/contrib/beanie/helpers.py
@@ -79,11 +79,16 @@ def isvalid_field(document: Type[Document], field: str) -> bool:
         return False
 
 
+def resolve_expression_field_name(field: ExpressionField) -> str:
+    field_str = str(field)
+    return "id" if field_str == "_id" else field_str
+
+
 def normalize_field_list(field_list: List[Union[str, ExpressionField]]) -> List[str]:
     converted_field_list = []
     for field in field_list:
         if isinstance(field, ExpressionField):
-            field_name = str(field)
+            field_name = resolve_expression_field_name(field)
         elif isinstance(field, str):
             field_name = field
         else:

--- a/starlette_admin/contrib/beanie/view.py
+++ b/starlette_admin/contrib/beanie/view.py
@@ -10,8 +10,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    get_args,
-    get_origin,
 )
 
 import bson.errors
@@ -22,9 +20,7 @@ from beanie.operators import Or, RegEx, Text
 from pydantic import ValidationError
 from starlette.requests import Request
 from starlette_admin._types import RequestAction
-from starlette_admin.contrib.beanie.converters import (
-    BeanieModelConverter,
-)
+from starlette_admin.contrib.beanie.converters import BeanieModelConverter
 from starlette_admin.contrib.beanie.helpers import (
     BeanieLogicalOperator,
     build_order_clauses,
@@ -70,8 +66,6 @@ class ModelView(BaseModelView, Generic[T]):
 
         self.fields_pydantic = list(document.model_fields.items())
 
-        self.field_infos = []
-        self.link_fields = []
         self.exclude_fields_from_create = [
             *self.exclude_fields_from_create,
             "revision_id",
@@ -88,39 +82,25 @@ class ModelView(BaseModelView, Generic[T]):
         ]
 
         self.exclude_fields_from_create = normalize_field_list(
-            field_list=self.exclude_fields_from_create, document=document
+            field_list=self.exclude_fields_from_create
         )
         self.exclude_fields_from_edit = normalize_field_list(
-            field_list=self.exclude_fields_from_edit, document=document
+            field_list=self.exclude_fields_from_edit
         )
         self.exclude_fields_from_list = normalize_field_list(
-            field_list=self.exclude_fields_from_list, document=document
+            field_list=self.exclude_fields_from_list
         )
         self.exclude_fields_from_detail = normalize_field_list(
-            field_list=self.exclude_fields_from_detail, document=document
+            field_list=self.exclude_fields_from_detail
         )
 
-        for name, field in document.model_fields.items():
-            field_type = field.annotation
-            while get_origin(field_type) is Union:
-                field_type = get_args(field_type)[0]
-            if is_link_type(field_type) or is_list_of_links_type(field_type):
-                self.link_fields.append(
-                    {"name": name, "type": field_type, "required": field.is_required()}
-                )
-            else:
-                self.field_infos.append(
-                    {"name": name, "type": field_type, "required": field.is_required()}
-                )
+        if self.fields is None or len(self.fields) == 0:
+            self.fields = document.model_fields.keys()
+
         self.fields = list(
             (converter or BeanieModelConverter()).convert_fields_list(
-                fields=self.field_infos, model=self.document
+                fields=self.fields, model=self.document
             )
-        )
-
-        self.fields.extend(
-            BeanieModelConverter().conv_link(**link_field)
-            for link_field in self.link_fields
         )
 
         super().__init__()
@@ -258,16 +238,19 @@ class ModelView(BaseModelView, Generic[T]):
         try:
 
             for key in data:
-                field_type = self.document.model_fields[key].annotation
-                if is_link_type(field_type):
-                    if not isinstance(data[key], PydanticObjectId):
-                        data[key] = (
-                            None if not data[key] else PydanticObjectId(data[key])
-                        )
-                elif is_list_of_links_type(field_type):
-                    data[key] = [PydanticObjectId(item) for item in data[key] if item]
+                if key in self.document.model_fields:
+                    field_type = self.document.model_fields[key].annotation
+                    if is_link_type(field_type):
+                        if not isinstance(data[key], PydanticObjectId):
+                            data[key] = (
+                                None if not data[key] else PydanticObjectId(data[key])
+                            )
+                    elif is_list_of_links_type(field_type):
+                        data[key] = [
+                            PydanticObjectId(item) for item in data[key] if item
+                        ]
 
-                setattr(doc, key, data[key])
+                    setattr(doc, key, data[key])
 
             # ensure doc still passes validation
             validated_doc: T = self.document.model_validate(doc.model_dump())

--- a/tests/beanie/test_view.py
+++ b/tests/beanie/test_view.py
@@ -119,6 +119,7 @@ class TestBeanieView:
             ]
             exclude_fields_from_create = [Product.created_at]
             exclude_fields_from_edit = ["created_at"]
+            exclude_fields_from_list = [Product.id]
 
         admin = Admin()
         admin.add_view(StoreView(Store))

--- a/tests/beanie/test_view_meta.py
+++ b/tests/beanie/test_view_meta.py
@@ -1,0 +1,27 @@
+from beanie import Document
+from starlette_admin.contrib.beanie.view import ModelView
+from starlette_admin.fields import StringField, TagsField
+
+
+def test_fields_customisation():
+    class MyModel(Document):
+        tags: list[str]
+        name: str
+
+    class MyModelView(ModelView):
+        fields = ["id", "name", TagsField("tags")]
+        exclude_fields_from_create = ["tags"]
+        exclude_fields_from_detail = ["id"]
+        exclude_fields_from_edit = ["name"]
+
+    assert MyModelView(MyModel).fields == [
+        StringField(
+            "id",
+            label="id",
+            exclude_from_create=True,
+            exclude_from_edit=True,
+            exclude_from_detail=True,
+        ),
+        StringField("name", exclude_from_edit=True, required=True),
+        TagsField("tags", exclude_from_create=True),
+    ]


### PR DESCRIPTION
This fixes the beanie contrib always taking the fields from the beanie document ignoring fields given in starlette admin view and also not supporting base starlette admin fields.

Previously, the `starlette_admin.contrib.beanie.ModelView` would override any `fields` list explicitly defined in its subclass. Instead, it would automatically introspect the linked Beanie document model and generate all fields from it.

This behavior had two main consequences:
1.  **Limited Customization:** Users could not precisely control which fields were displayed in the admin interface.
2.  **No Support for Base Fields:** It prevented the use of specialized `starlette-admin` base fields (e.g., `ImageField`, `StringField`, etc.) because the auto-generation process would ignore or overwrite these custom field definitions.

This commit modifies the Beanie `ModelView`'s initialization logic to use the given `fields` in the ModelView. If no fields are given then it generates the fields from the document/model as done in other contribs like sqlalchemy and odomantic.

This enables full control over the fields displayed for Beanie documents and allows the seamless integration of all `starlette-admin` field components for rich customization of admin views.

Fixes #675 