### PR TITLE
fix(beanie): serialization error when id excluded in list

### DIFF
--- a/starlette_admin/contrib/beanie/view.py
+++ b/starlette_admin/contrib/beanie/view.py
@@ -232,6 +232,9 @@ class ModelView(BaseModelView, Generic[T]):
 
         return getattr(obj, not_none(self.pk_attr))
 
+    async def get_serialized_pk_value(self, request: Request, obj: Any) -> Any:
+        return str(await self.get_pk_value(request, obj))
+
     async def create(self, request: Request, data: dict) -> T:
         data = {
             k: v

--- a/tests/beanie/test_view.py
+++ b/tests/beanie/test_view.py
@@ -91,8 +91,11 @@ class TestBeanieView:
             exclude_fields_from_create = [Product.created_at]
             exclude_fields_from_edit = ["created_at"]
 
+        class StoreView(ModelView):
+            exclude_fields_from_list = ["id"]
+
         admin = Admin()
-        admin.add_view(ModelView(Store))
+        admin.add_view(StoreView(Store))
         admin.add_view(ProductView(Product))
         admin.add_view(ModelView(User))
         admin.add_view(ProductDescriptionTestView(ProductDescriptionTest))


### PR DESCRIPTION
This commit fixes JSON serialization error when 'id' is excluded from list view in beanie backend.
Fixes #677 