### PR TITLE
Fix umerical filter with 0 is sent to backend as ""

### DIFF
--- a/starlette_admin/statics/js/list.js
+++ b/starlette_admin/statics/js/list.js
@@ -271,7 +271,7 @@ $(function () {
       } else if (c.condition == "!between") {
         cnd["not_between"] = c.value;
       } else if (c_map[c.condition]) {
-        cnd[c_map[c.condition]] = c.value1 || "";
+        cnd[c_map[c.condition]] = c.value1 ?? "";
       }
       d[c.origData] = cnd;
     }


### PR DESCRIPTION
Fixes issue #706 

I've changed `||` to `??` so 0 would be sent to BE as well as `false` which might be a text somewhere (though probably it's less common).