### PR TITLE
Fix CustomView is_active not working for custom root path

### DIFF
--- a/starlette_admin/views.py
+++ b/starlette_admin/views.py
@@ -171,7 +171,7 @@ class CustomView(BaseView):
         )
 
     def is_active(self, request: Request) -> bool:
-        return request.scope["path"] == self.path
+        return request.scope["path"] == request.scope["root_path"] + self.path
 
 
 class BaseModelView(BaseView):


### PR DESCRIPTION
My custom view "docs" was not highlighted in the navigation because the path `/admin/docs` was compared to `/docs`. This is fixed my this PR.

Example:
```python
admin = Admin(engine, title="MyAdminView")
admin.add_view(
    CustomView(
        label="API Docs",
        path="/docs",
        template_path="docs.html",
        icon="fa fa-book"
    )
)
admin.mount_to(app)
```