### PR TITLE
Refactor: Remove HTTP_422_UNPROCESSABLE_ENTITY deprecation warning for compatible versions

### DIFF
--- a/starlette_admin/auth.py
+++ b/starlette_admin/auth.py
@@ -6,12 +6,9 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Union
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.routing import Match, Mount, Route, WebSocketRoute
-from starlette.status import (
-    HTTP_400_BAD_REQUEST,
-    HTTP_422_UNPROCESSABLE_ENTITY,
-)
+from starlette.status import HTTP_303_SEE_OTHER, HTTP_400_BAD_REQUEST
 from starlette_admin.exceptions import FormValidationError, LoginFailed
-from starlette_admin.helpers import wrap_endpoint_with_kwargs
+from starlette_admin.helpers import HTTP_422, wrap_endpoint_with_kwargs
 from starlette_admin.i18n import lazy_gettext as _
 
 if TYPE_CHECKING:
@@ -22,9 +19,6 @@ from urllib.parse import urlencode
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
-from starlette.status import (
-    HTTP_303_SEE_OTHER,
-)
 from starlette.types import ASGIApp
 
 
@@ -255,7 +249,7 @@ class AuthProvider(BaseAuthProvider):
                 request=request,
                 name="login.html",
                 context={"form_errors": errors, "_is_login_path": True},
-                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=HTTP_422,
             )
         except LoginFailed as error:
             return admin.templates.TemplateResponse(

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -22,14 +22,13 @@ from starlette.status import (
     HTTP_400_BAD_REQUEST,
     HTTP_403_FORBIDDEN,
     HTTP_404_NOT_FOUND,
-    HTTP_422_UNPROCESSABLE_ENTITY,
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
 from starlette.templating import Jinja2Templates
 from starlette_admin._types import RequestAction
 from starlette_admin.auth import BaseAuthProvider
 from starlette_admin.exceptions import ActionFailed, FormValidationError
-from starlette_admin.helpers import get_file_icon, not_none
+from starlette_admin.helpers import HTTP_422, get_file_icon, not_none
 from starlette_admin.i18n import (
     I18nConfig,
     LocaleMiddleware,
@@ -467,7 +466,7 @@ class BaseAdmin:
                 request=request,
                 name=model.create_template,
                 context=config,
-                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=HTTP_422,
             )
         pk = await model.get_pk_value(request, obj)
         url = request.url_for(self.route_name + ":list", identity=model.identity)
@@ -516,7 +515,7 @@ class BaseAdmin:
                 request=request,
                 name=model.edit_template,
                 context=config,
-                status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=HTTP_422,
             )
         pk = await model.get_pk_value(request, obj)
         url = request.url_for(self.route_name + ":list", identity=model.identity)

--- a/starlette_admin/helpers.py
+++ b/starlette_admin/helpers.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from markupsafe import escape
+from starlette import status
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette_admin._types import RequestAction
@@ -21,6 +22,12 @@ from starlette_admin.exceptions import FormValidationError
 
 if TYPE_CHECKING:
     from starlette_admin.fields import BaseField
+
+HTTP_422 = (
+    status.HTTP_422_UNPROCESSABLE_CONTENT
+    if hasattr(status, "HTTP_422_UNPROCESSABLE_CONTENT")
+    else status.HTTP_422_UNPROCESSABLE_ENTITY
+)
 
 
 def prettify_class_name(name: str) -> str:


### PR DESCRIPTION
Related to issue #721 
Deprecated names in Starlette