### PR TITLE
added optional jsonschema validation to jsonfield

### DIFF
--- a/starlette_admin/fields.py
+++ b/starlette_admin/fields.py
@@ -936,10 +936,15 @@ class ArrowField(DateTimeField):
 class JSONField(BaseField):
     """
     This field render jsoneditor and represent a value that stores python dict object.
-    Erroneous input is ignored and will not be accepted as a value."""
+    Erroneous input is ignored and will not be accepted as a value.
+
+    You may optionally use the `validation_schema` property to provide a dict with
+    a [JSONSchema](https://json-schema.org/) to have it be used to provide
+    validation feedback on the client side."""
 
     height: str = "20em"
     modes: Optional[Sequence[str]] = None
+    validation_schema: Optional[Dict[str, Any]] = None
     render_function_key: str = "json"
     form_template: str = "forms/json.html"
     display_template: str = "displays/json.html"

--- a/starlette_admin/statics/js/form.js
+++ b/starlette_admin/statics/js/form.js
@@ -40,6 +40,7 @@ registerFieldInitializer(function (element) {
       this,
       {
         modes: String(el.data("modes")).split(","),
+        schema: el.data("validationSchema") ?? undefined,
         onChangeText: function (json) {
           $(`input[name=${name}]`).val(json);
         },

--- a/starlette_admin/templates/forms/json.html
+++ b/starlette_admin/templates/forms/json.html
@@ -1,6 +1,7 @@
 <div id="{{ field.id }}"
      class="field-json {% if error %}is-invalid{% endif %}"
      style="height: {{ field.height }}"
+     data-validation-schema="{{ field.validation_schema|tojson|forceescape }}"
      data-modes="{{ field.modes | join(',') }}">
 </div>
 <input type="text"


### PR DESCRIPTION
This PR adds optional JSONSchema validation to `JSONField` by leveraging the already existing support for this in JSONEditor.

It introduces a new `validation_schema` attribute to `JSONField`, which can optionally be used to pass a dict with the JSON schema. For example:

```python


class TodoView(ModelView):
    fields = (
        Todo.title,
        Todo.done,
        JSONField(
            "stuff",
            validation_schema={
                "type": "object",
                "required": ["owner"],
                "properties": {
                    "owner": {"type": "string"},
                }
            }
        ),
    )
```

When using the admin to create or edit an instance, the UI will show a small symbol if there are validation errors with a descriptive tooltip message, as seen below:

<img width="1935" height="934" alt="image" src="https://github.com/user-attachments/assets/ff931a84-aa25-47b4-b5b1-ca5742d30b50" />

This PR really only glues things up for starlette-admin to use the default functionality provided in upstream JSONEditor - it does not add any custom validation event handlers or any type of further customization.

---
- fixes #735