### PR TITLE
Quote jsonfield name when selecting in order to account for possible numeric parts in the name

### DIFF
--- a/starlette_admin/statics/js/form.js
+++ b/starlette_admin/statics/js/form.js
@@ -42,10 +42,10 @@ registerFieldInitializer(function (element) {
         modes: String(el.data("modes")).split(","),
         schema: el.data("validationSchema") ?? undefined,
         onChangeText: function (json) {
-          $(`input[name=${name}]`).val(json);
+          $(`input[name='${name}']`).val(json);
         },
       },
-      JSON.parse($(`input[name=${name}]`).val())
+      JSON.parse($(`input[name='${name}']`).val())
     );
   });
 


### PR DESCRIPTION
This PR makes a small change to the way JSONFieldfields are selected during their respective field initializer function. The change is merely quoting the element's name when finding it with JQuery.

As mentioned in #737, this changes makes it possible to use JSONField together with ListField.

---

- fixes #737