### PR TITLE
fix(admin): swallow get_admin_user / get_admin_config exceptions in template filter (#754)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args:

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -246,16 +246,17 @@ class BaseAdmin:
         templates.env.filters["is_link"] = lambda res: isinstance(res, Link)
         templates.env.filters["is_model"] = lambda res: isinstance(res, BaseModelView)
         templates.env.filters["is_dropdown"] = lambda res: isinstance(res, DropDown)
+
         # Wrap provider callbacks in a safe filter so an unauthenticated
         # request reaching the layout template (e.g. the exception handler
         # rendering error.html for a missing static asset before the auth
         # redirect fires — issue #754) doesn't crash get_admin_user's
         # session lookup and turn a 404 into a 500.
-        def _safe_filter(fn):  # noqa: ANN001,ANN202 — jinja filter shape
+        def _safe_filter(fn):
             if fn is None:
                 return None
 
-            def _wrapped(request):  # noqa: ANN001
+            def _wrapped(request):
                 try:
                     return fn(request)
                 except Exception:

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -246,10 +246,27 @@ class BaseAdmin:
         templates.env.filters["is_link"] = lambda res: isinstance(res, Link)
         templates.env.filters["is_model"] = lambda res: isinstance(res, BaseModelView)
         templates.env.filters["is_dropdown"] = lambda res: isinstance(res, DropDown)
-        templates.env.filters["get_admin_user"] = (
+        # Wrap provider callbacks in a safe filter so an unauthenticated
+        # request reaching the layout template (e.g. the exception handler
+        # rendering error.html for a missing static asset before the auth
+        # redirect fires — issue #754) doesn't crash get_admin_user's
+        # session lookup and turn a 404 into a 500.
+        def _safe_filter(fn):  # noqa: ANN001,ANN202 — jinja filter shape
+            if fn is None:
+                return None
+
+            def _wrapped(request):  # noqa: ANN001
+                try:
+                    return fn(request)
+                except Exception:
+                    return None
+
+            return _wrapped
+
+        templates.env.filters["get_admin_user"] = _safe_filter(
             self.auth_provider.get_admin_user if self.auth_provider else None
         )
-        templates.env.filters["get_admin_config"] = (
+        templates.env.filters["get_admin_config"] = _safe_filter(
             self.auth_provider.get_admin_config if self.auth_provider else None
         )
         templates.env.filters["tojson"] = lambda data: json.dumps(data, default=str)

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -250,7 +250,7 @@ class BaseAdmin:
         # Wrap provider callbacks in a safe filter so an unauthenticated
         # request reaching the layout template (e.g. the exception handler
         # rendering error.html for a missing static asset before the auth
-        # redirect fires — issue #754) doesn't crash get_admin_user's
+        # redirect fires, issue #754) doesn't crash get_admin_user's
         # session lookup and turn a 404 into a 500.
         def _safe_filter(fn):
             if fn is None:


### PR DESCRIPTION
## Summary

When \`StaticFiles\` returns 404 for a missing asset (e.g. a crawler hitting \`/admin/statics/js/vendor/tabler.min-1.1.0.js.map\` before the source map exists on disk), \`admin_app\`'s \`exception_handler\` rebuilds the response through \`_render_error\` → \`error.html\` → \`layout.html\`. \`layout.html\` invokes the \`get_admin_user\` filter. Provider implementations typically read \`request.session['name']\` directly, so an unauthenticated crawler has no session and raises \`KeyError\`, turning the 404 into a 500 in the auth layer.

Stack trace from the issue matches this path: the 500 originates in the user's \`get_admin_user\` via the Jinja filter call on the rendered error page.

## Fix

Wrap \`get_admin_user\` / \`get_admin_config\` in a small \`_safe_filter\` helper that returns \`None\` on any exception, so an unauthenticated render path gracefully falls back to the anonymous layout. Provider contracts are unchanged for authenticated requests.

Fixes #754

## Test plan

- [x] \`python3 -c 'import ast; ast.parse(open(\"starlette_admin/base.py\").read())'\`, syntax clean
- [x] Logic trace: authenticated request → filter delegates to provider callable (unchanged); unauthenticated request that ends up in \`error.html\` → provider raises → filter returns \`None\` → \`layout.html\`'s \`{% set current_user = (request | get_admin_user) %}\` gets \`None\` and renders the anonymous layout