### PR TITLE
fix: make "Yes, delete" button text translatable in row delete action (#751)

### DIFF
--- a/starlette_admin/views.py
+++ b/starlette_admin/views.py
@@ -500,7 +500,7 @@ class BaseModelView(BaseView):
         text=_("Delete"),
         confirmation=_("Are you sure you want to delete this item?"),
         icon_class="fa-solid fa-trash",
-        submit_btn_text="Yes, delete",
+        submit_btn_text=_("Yes, delete"),
         submit_btn_class="btn-danger",
         action_btn_class="btn-danger",
     )


### PR DESCRIPTION
## Summary
The submit button text for the built-in single-row delete action was hardcoded as `"Yes, delete"` instead of being wrapped in `_()` for internationalization.

## Changes
- `starlette_admin/views.py:503` — wrap `submit_btn_text` with `_()` → `_("Yes, delete")`

## Testing
- All existing tests pass (`test_i18n.py`, `test_views.py`, `test_actions.py`)
- Lint passes via `hatch run test:lint`