### PR TITLE
fix: JsonField now correctly renders falsy values in list view (#734)

### DIFF
--- a/starlette_admin/statics/js/render.js
+++ b/starlette_admin/statics/js/render.js
@@ -64,7 +64,7 @@ const render = {
   },
   json: function render(data, type, full, meta, fieldOptions) {
     if (type != "display") return escape(JSON.stringify(data));
-    if (data) {
+    if (data != null) {
       return `<span class="align-middle d-inline-block text-truncate" data-toggle="tooltip" data-placement="bottom" title='${escape(
         JSON.stringify(data)
       )}' style="max-width: 30em;">${pretty_print_json(data)}</span>`;

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 from pydantic import Field
@@ -506,3 +506,41 @@ class TestViews:
             )
             == 1
         )
+
+    def test_json_field_falsy_values(self):
+        """Test that JSONField correctly serializes falsy values in API response."""
+
+        class FalsyModel(DummyBaseModel):
+            json_field: Optional[Any] = None
+
+        class FalsyModelView(DummyModelView):
+            fields = [
+                IntegerField("id"),
+                JSONField("json_field"),
+            ]
+            model = FalsyModel
+            db = {}
+            seq = 1
+
+        admin = BaseAdmin()
+        app = Starlette()
+        admin.add_view(FalsyModelView)
+        admin.mount_to(app)
+        client = TestClient(app)
+
+        # Create with a normal dict value first
+        response = client.post(
+            "/admin/falsy-model/create",
+            data={"json_field": '{"key":"value"}'},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+        # Now manually set falsy values directly on the model and verify API serialization
+        falsy_values = [0, False, "", [], {}, None]
+        for val in falsy_values:
+            FalsyModelView.db[99] = FalsyModel(id=99, json_field=val)
+            response = client.get("/admin/api/falsy-model?pks=99")
+            assert response.status_code == 200
+            item = response.json()["items"][0]
+            assert item["json_field"] == val, f"Expected {val!r}, got {item['json_field']!r}"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -543,4 +543,6 @@ class TestViews:
             response = client.get("/admin/api/falsy-model?pks=99")
             assert response.status_code == 200
             item = response.json()["items"][0]
-            assert item["json_field"] == val, f"Expected {val!r}, got {item['json_field']!r}"
+            assert (
+                item["json_field"] == val
+            ), f"Expected {val!r}, got {item['json_field']!r}"


### PR DESCRIPTION
## Summary
The json render function used `if (data)` which incorrectly treated falsy values (`0`, `false`, `""`, `[]`, `{}`) as null, displaying them as `-null-` in the list view.

## Changes
- `starlette_admin/statics/js/render.js:67` — Changed `if (data)` to `if (data != null)` so only actual null/undefined displays as `-null-`
- `tests/test_views.py` — Added `test_json_field_falsy_values` to verify API correctly serializes falsy JSON values

## Testing
- New test passes: `test_json_field_falsy_values`
- All 15 views tests pass