### PR TITLE
fix: CustomView added after mount_to is now accessible (#731)

### DIFF
--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -99,6 +99,7 @@ class BaseAdmin:
         self._views: List[BaseView] = []
         self._models: List[BaseModelView] = []
         self.routes: List[Union[Route, Mount]] = []
+        self._mounted_app: Optional[Starlette] = None
         self.debug = debug
         self.i18n_config = i18n_config
         self.timezone_config = timezone_config
@@ -270,15 +271,20 @@ class BaseAdmin:
             for sub_view in view.views:
                 self.setup_view(sub_view)
         elif isinstance(view, CustomView):
-            self.routes.insert(
-                0,
-                Route(
+            route = Route(
+                view.path,
+                endpoint=self._render_custom_view(view),
+                methods=view.methods,
+                name=view.name,
+            )
+            self.routes.insert(0, route)
+            if self._mounted_app is not None:
+                self._mounted_app.router.add_route(
                     view.path,
-                    endpoint=self._render_custom_view(view),
+                    endpoint=route.endpoint,
                     methods=view.methods,
                     name=view.name,
-                ),
-            )
+                )
         elif isinstance(view, BaseModelView):
             view._find_foreign_model = self._find_model_from_identity
             self._models.append(view)
@@ -564,6 +570,7 @@ class BaseAdmin:
             exception_handlers={HTTPException: self._render_error},
         )
         admin_app.state.ROUTE_NAME = self.route_name
+        self._mounted_app = admin_app
         app.mount(
             self.base_url,
             app=admin_app,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -506,3 +506,25 @@ class TestViews:
             )
             == 1
         )
+
+    def test_custom_view_after_mount(self):
+        """Test that CustomView added after mount_to is still accessible."""
+
+        admin = BaseAdmin()
+        app = Starlette()
+        admin.add_view(
+            CustomView(label="Home", path="/home", template_path="index.html")
+        )
+        admin.mount_to(app)
+
+        # Add CustomView after mount
+        admin.add_view(
+            CustomView(label="Dashboard", path="/dashboard", template_path="index.html")
+        )
+
+        client = TestClient(app)
+        # Both CustomViews should be accessible
+        response = client.get("/admin/home")
+        assert response.status_code == 200
+        response = client.get("/admin/dashboard")
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
When CustomView was added via `add_view()` after `mount_to()` had already been called, the route was inserted into `self.routes` but not into the already-created Starlette sub-application, causing 404 errors.

ModelViews were not affected because their routes are registered during `init_routes()` before `mount_to()` is called.

## Changes
- `starlette_admin/base.py:102` — Added `self._mounted_app = None` in `__init__`
- `starlette_admin/base.py:573` — Save reference to created `admin_app` in `mount_to()`
- `starlette_admin/base.py:274-283` — In `setup_view()`, if mounted, also add route to mounted app's router via `add_route()`
- `tests/test_views.py` — Added `test_custom_view_after_mount` test

## Testing
- New test `test_custom_view_after_mount` passes
- All 15 views tests pass