### PR TITLE
fix: preserve leading newlines in TextArea field (#732)

### DIFF
--- a/starlette_admin/templates/forms/textarea.html
+++ b/starlette_admin/templates/forms/textarea.html
@@ -1,5 +1,6 @@
 <div class="{% if error %}{{ field.error_class }}{% endif %}">
-    <textarea id="{{ field.id }}" name="{{ field.id }}" data-bs-toggle="autosize" class="{{ field.class_ }}{% if error %} {{ field.error_class }}{% endif %}" {{ field.input_params() | safe }}>{% if data -%}{{ data }}{% endif %}</textarea>
+    <textarea id="{{ field.id }}" name="{{ field.id }}" data-bs-toggle="autosize" class="{{ field.class_ }}{% if error %} {{ field.error_class }}{% endif %}" {{ field.input_params() | safe }}>{% if data %}
+{{ data }}{% endif %}</textarea>
     {% if field.help_text -%}
         <small class="form-hint">{{ field.help_text }}</small>
     {% endif -%}


### PR DESCRIPTION
## Summary
TextArea field values with leading newlines (e.g. `\n\nline2`) lost the first newline when rendered in the edit form. This is because the HTML spec states that browsers ignore the first newline immediately after the `<textarea>` opening tag.

## Root Cause
The original template used `{% if data -%}` with whitespace-trimming (`-%}`), which produced:
```
<textarea...>{{ data }}</textarea>
```
When `data` was `\n\nline2`, the output was `<textarea>\n\nline2</textarea>`, and the browser consumed the first `\n`.

## Fix
`starlette_admin/templates/forms/textarea.html` — Removed whitespace-trimming and added an explicit newline before `{{ data }}`:
```
<textarea...>
{{ data }}</textarea>
```
Now the browser consumes the template's newline, preserving the data's leading newlines.

## Testing
- Verified API returns correct value with leading newlines
- Verified edit page textarea content preserves leading newlines
- Verified "Save and Continue Editing" cycle preserves content