### PR TITLE
fix: mark HasOne as required when foreign key is NOT NULL (#486)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,9 +183,6 @@ parallel = true
 concurrency = ["thread", "greenlet"]
 source = ["starlette_admin", "tests"]
 
-[tool.pytest]
-asyncio_mode = "auto"
-
 [tool.pytest.ini_options]
 asyncio_mode="auto"
 asyncio_default_fixture_loop_scope="function"

--- a/starlette_admin/contrib/sqla/converters.py
+++ b/starlette_admin/contrib/sqla/converters.py
@@ -104,7 +104,14 @@ class BaseSQLAModelConverter(BaseModelConverter):
                     if attr.direction.name == "MANYTOONE" or (
                         attr.direction.name == "ONETOMANY" and not attr.uselist
                     ):
-                        converted_fields.append(HasOne(attr.key, identity=identity))
+                        # Determine required from the local foreign key column(s).
+                        # If all local columns are NOT NULL, the relationship is required.
+                        required = all(
+                            not col.nullable for col in attr.local_columns
+                        )
+                        converted_fields.append(
+                            HasOne(attr.key, identity=identity, required=required)
+                        )
                     else:
                         converted_fields.append(
                             HasMany(

--- a/starlette_admin/contrib/sqla/converters.py
+++ b/starlette_admin/contrib/sqla/converters.py
@@ -106,9 +106,7 @@ class BaseSQLAModelConverter(BaseModelConverter):
                     ):
                         # Determine required from the local foreign key column(s).
                         # If all local columns are NOT NULL, the relationship is required.
-                        required = all(
-                            not col.nullable for col in attr.local_columns
-                        )
+                        required = all(not col.nullable for col in attr.local_columns)
                         converted_fields.append(
                             HasOne(attr.key, identity=identity, required=required)
                         )


### PR DESCRIPTION
## Summary
When a MANYTOONE relationship's local foreign key column is NOT NULL, the HasOne field was not marked as required in forms. This caused the form to not show the required indicator and not enforce the constraint.

## Root Cause
In `BaseSQLAModelConverter.convert_fields_list`, `HasOne` was always created with `required=False` regardless of the foreign key column's nullable setting.

## Fix
`starlette_admin/contrib/sqla/converters.py:107-113` — Check all local columns of the RelationshipProperty. If all local columns are NOT NULL, set `required=True` on the HasOne field.

```python
required = all(not col.nullable for col in attr.local_columns)
converted_fields.append(HasOne(attr.key, identity=identity, required=required))
```

## Testing
- `tests/test_converters.py` — 2 tests pass
- `tests/test_views.py` — 14 tests pass
- Manual verification with nullable and non-nullable FK columns

## Additional
Includes a chore commit to fix pyproject.toml pytest config conflict that was blocking test execution.