### PR TITLE
feat: support pretty printing in tojson filter (#681)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,9 +183,6 @@ parallel = true
 concurrency = ["thread", "greenlet"]
 source = ["starlette_admin", "tests"]
 
-[tool.pytest]
-asyncio_mode = "auto"
-
 [tool.pytest.ini_options]
 asyncio_mode="auto"
 asyncio_default_fixture_loop_scope="function"

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -252,7 +252,7 @@ class BaseAdmin:
         templates.env.filters["get_admin_config"] = (
             self.auth_provider.get_admin_config if self.auth_provider else None
         )
-        templates.env.filters["tojson"] = lambda data: json.dumps(data, default=str)
+        templates.env.filters["tojson"] = lambda data, indent=None: json.dumps(data, default=str, indent=indent)
         templates.env.filters["file_icon"] = get_file_icon
         templates.env.filters["to_model"] = (
             lambda identity: self._find_model_from_identity(identity)

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -252,7 +252,9 @@ class BaseAdmin:
         templates.env.filters["get_admin_config"] = (
             self.auth_provider.get_admin_config if self.auth_provider else None
         )
-        templates.env.filters["tojson"] = lambda data, indent=None: json.dumps(data, default=str, indent=indent)
+        templates.env.filters["tojson"] = lambda data, indent=None: json.dumps(
+            data, default=str, indent=indent
+        )
         templates.env.filters["file_icon"] = get_file_icon
         templates.env.filters["to_model"] = (
             lambda identity: self._find_model_from_identity(identity)


### PR DESCRIPTION
## Summary
The custom `tojson` filter now accepts an optional `indent` parameter, enabling pretty printed JSON output in templates. Default behavior is unchanged.

## Changes
- `starlette_admin/base.py:255` — Added `indent=None` parameter to the `tojson` filter lambda

## Usage
```jinja2
{{ data|tojson }}           # compact (default, backward compatible)
{{ data|tojson(indent=2) }} # pretty printed with 2-space indent
```

Users can override the JSONField display template to use pretty printing:
```python
JSONField("json_data", display_template="admin/json_pretty_print.html")
```

With a custom template:
```html
<div class="field-json">{{ data|tojson(indent=2) }}</div>
```

## Testing
- All 16 tests pass (test_views.py + test_converters.py)

## Additional
Includes chore commit to fix pyproject.toml pytest config conflict.