### PR TITLE
feat: support additional template loaders and static packages (#743)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,9 +183,6 @@ parallel = true
 concurrency = ["thread", "greenlet"]
 source = ["starlette_admin", "tests"]
 
-[tool.pytest]
-asyncio_mode = "auto"
-
 [tool.pytest.ini_options]
 asyncio_mode="auto"
 asyncio_default_fixture_loop_scope="function"

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -3,6 +3,7 @@ from json import JSONDecodeError
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Type, Union
 
 from jinja2 import (
+    BaseLoader,
     ChoiceLoader,
     Environment,
     FileSystemLoader,
@@ -64,6 +65,8 @@ class BaseAdmin:
         i18n_config: Optional[I18nConfig] = None,
         timezone_config: Optional[TimezoneConfig] = None,
         favicon_url: Optional[str] = None,
+        additional_template_loaders: Optional[Sequence[BaseLoader]] = None,
+        additional_static_packages: Optional[Sequence[str]] = None,
     ):
         """
         Parameters:
@@ -80,6 +83,12 @@ class BaseAdmin:
             i18n_config: i18n configuration
             timezone_config: timezone configuration
             favicon_url: URL of favicon.
+            additional_template_loaders: Additional Jinja2 template loaders to
+                register. Useful for custom fields or third-party packages that
+                ship their own templates.
+            additional_static_packages: Additional Python package names to serve
+                static files from. Useful for custom fields or third-party
+                packages that ship their own static assets.
         """
         self.title = title
         self.base_url = base_url
@@ -102,6 +111,12 @@ class BaseAdmin:
         self.debug = debug
         self.i18n_config = i18n_config
         self.timezone_config = timezone_config
+        self._additional_template_loaders: Sequence[BaseLoader] = (
+            list(additional_template_loaders) if additional_template_loaders else []
+        )
+        self._additional_static_packages: Sequence[str] = (
+            list(additional_static_packages) if additional_static_packages else []
+        )
         self._setup_templates()
         self.init_locale()
         self.init_auth()
@@ -149,7 +164,8 @@ class BaseAdmin:
             self.auth_provider.setup_admin(self)
 
     def init_routes(self) -> None:
-        statics = StaticFiles(directory=self.statics_dir, packages=["starlette_admin"])
+        static_packages = ["starlette_admin", *self._additional_static_packages]
+        statics = StaticFiles(directory=self.statics_dir, packages=static_packages)
         self.routes.extend(
             [
                 Mount("/statics", app=statics, name="statics"),
@@ -207,20 +223,20 @@ class BaseAdmin:
             self._views.append(self.index_view)
 
     def _setup_templates(self) -> None:
-        env = Environment(
-            loader=ChoiceLoader(
-                [
-                    FileSystemLoader(self.templates_dir),
-                    PackageLoader("starlette_admin", "templates"),
-                    PrefixLoader(
-                        {
-                            "@starlette-admin": PackageLoader(
-                                "starlette_admin", "templates"
-                            ),
-                        }
+        loaders: List[BaseLoader] = [
+            FileSystemLoader(self.templates_dir),
+            PackageLoader("starlette_admin", "templates"),
+            PrefixLoader(
+                {
+                    "@starlette-admin": PackageLoader(
+                        "starlette_admin", "templates"
                     ),
-                ]
+                }
             ),
+            *self._additional_template_loaders,
+        ]
+        env = Environment(
+            loader=ChoiceLoader(loaders),
             extensions=["jinja2.ext.i18n"],
             autoescape=True,
         )

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -228,9 +228,7 @@ class BaseAdmin:
             PackageLoader("starlette_admin", "templates"),
             PrefixLoader(
                 {
-                    "@starlette-admin": PackageLoader(
-                        "starlette_admin", "templates"
-                    ),
+                    "@starlette-admin": PackageLoader("starlette_admin", "templates"),
                 }
             ),
             *self._additional_template_loaders,


### PR DESCRIPTION
## Summary
Allows third-party packages and custom fields to register their own templates and static files with the admin interface.

## Changes
- `starlette_admin/base.py` — Added two new `BaseAdmin` parameters:
  - `additional_template_loaders: Sequence[BaseLoader]` — Extra Jinja2 template loaders
  - `additional_static_packages: Sequence[str]` — Extra Python packages for static files
- `_setup_templates()` — Includes additional loaders in the `ChoiceLoader`
- `init_routes()` — Includes additional packages in `StaticFiles`

## Usage
```python
from jinja2 import PackageLoader
from starlette_admin.contrib.sqla import Admin

admin = Admin(
    engine,
    additional_template_loaders=[PackageLoader("my_package", "templates")],
    additional_static_packages=["my_package"],
)
```

## Testing
- All 14 views tests pass
- Manual verification with `FileSystemLoader` and empty static packages

## Additional
Includes chore commit to fix pyproject.toml pytest config conflict.