### PR TITLE
feat: pre-fill create form with SQLAlchemy column defaults (#690)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,9 +183,6 @@ parallel = true
 concurrency = ["thread", "greenlet"]
 source = ["starlette_admin", "tests"]
 
-[tool.pytest]
-asyncio_mode = "auto"
-
 [tool.pytest.ini_options]
 asyncio_mode="auto"
 asyncio_default_fixture_loop_scope="function"

--- a/starlette_admin/base.py
+++ b/starlette_admin/base.py
@@ -293,6 +293,23 @@ class BaseAdmin:
             _("Model with identity %(identity)s not found") % {"identity": identity},
         )
 
+    def _get_default_values(self, model: BaseModelView) -> Dict[str, Any]:
+        """Extract default values from the model's column definitions.
+
+        For SQLAlchemy models, reads ``column.default.arg`` for each column
+        that has a Python-side default.  For other model types, returns an
+        empty dict.
+        """
+        defaults: Dict[str, Any] = {}
+        # Check if the underlying model has a __table__ attribute (SQLAlchemy)
+        sa_model = getattr(model, "model", None)
+        if sa_model is None or not hasattr(sa_model, "__table__"):
+            return defaults
+        for col in sa_model.__table__.columns:
+            if col.default is not None and hasattr(col.default, "arg"):
+                defaults[col.key] = col.default.arg
+        return defaults
+
     def _render_custom_view(
         self, custom_view: CustomView
     ) -> Callable[[Request], Awaitable[Response]]:
@@ -442,10 +459,17 @@ class BaseAdmin:
         request.state.action = RequestAction.CREATE
         identity = request.path_params.get("identity")
         model = self._find_model_from_identity(identity)
-        config = {"title": model.title(request), "model": model}
         if not model.is_accessible(request) or not model.can_create(request):
             raise HTTPException(HTTP_403_FORBIDDEN)
+        config: Dict[str, Any] = {
+            "title": model.title(request),
+            "model": model,
+        }
         if request.method == "GET":
+            # Pre-fill form fields with SQLAlchemy column defaults
+            default_values = self._get_default_values(model)
+            if default_values:
+                config["obj"] = default_values
             return self.templates.TemplateResponse(
                 request=request,
                 name=model.create_template,


### PR DESCRIPTION
## Summary
When rendering the create form, extract default values from the SQLAlchemy model's column definitions and pass them as the initial `obj` to the template. This pre-fills form fields with their database-defined defaults.

## Changes
- `starlette_admin/base.py` — Added `_get_default_values()` method that reads `column.default.arg` from the model's `__table__`
- `_render_create()` — On GET requests, calls `_get_default_values()` and passes the result as `obj` to the template context

## How it works
For SQLAlchemy models, the method iterates over `model.__table__.columns` and extracts `col.default.arg` for columns that have a Python-side default. For non-SQLAlchemy models, returns an empty dict (no change in behavior).

Example: a column defined as `status = Column(String(20), default='active')` will pre-fill the form field with `'active'`.

## Testing
- All 14 views tests pass
- Manual verification with SQLAlchemy model defaults

## Additional
Includes chore commit to fix pyproject.toml pytest config conflict.