### PR TITLE
Add dark mode

### DIFF
--- a/starlette_admin/statics/css/dark-mode.css
+++ b/starlette_admin/statics/css/dark-mode.css
@@ -1,0 +1,126 @@
+/*
+ * Dark mode fixes for bundled third-party widgets.
+ *
+ * Tabler/Bootstrap toggles dark mode via the `data-bs-theme="dark"` attribute
+ * on the <body>. The widgets bundled with starlette-admin (Select2, DataTables
+ * buttons and Flatpickr) do not ship dark variants, so we restyle them here.
+ */
+
+/* Select2 */
+body[data-bs-theme="dark"] .select2-dropdown,
+body[data-bs-theme="dark"] .select2-container--default .select2-selection--single,
+body[data-bs-theme="dark"] .select2-container--default .select2-selection--multiple,
+body[data-bs-theme="dark"] .select2-container--default .select2-selection--multiple .select2-selection__choice,
+body[data-bs-theme="dark"] .select2-container--default .select2-search--dropdown .select2-search__field,
+body[data-bs-theme="dark"] .select2-container--default .select2-results__option--selected {
+    background-color: #151f2c;
+    border: 1px solid #25384f;
+    color: #dce1e7;
+}
+body[data-bs-theme="dark"] .select2-container--default .select2-selection--single .select2-selection__rendered {
+    color: #dce1e7;
+}
+
+/* DataTables buttons */
+body[data-bs-theme="dark"] div.dt-button-collection {
+    background-color: #16202c;
+}
+body[data-bs-theme="dark"] .dtb-popover-close {
+    background-color: #1a2332;
+    color: #dce1e7;
+    border-color: #25384f;
+}
+body[data-bs-theme="dark"] .dtb-popover-close:hover {
+    background-color: #25384f;
+    color: #fff;
+}
+
+/* Flatpickr */
+body[data-bs-theme="dark"] .flatpickr-calendar {
+    background-color: #1a2332;
+    border-color: #25384f;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+body[data-bs-theme="dark"] .flatpickr-months .flatpickr-month,
+body[data-bs-theme="dark"] .flatpickr-current-month .flatpickr-monthDropdown-months,
+body[data-bs-theme="dark"] .flatpickr-weekdays,
+body[data-bs-theme="dark"] .flatpickr-weekdaycontainer {
+    background-color: #1a2332;
+    color: #dce1e7;
+}
+body[data-bs-theme="dark"] .flatpickr-months .flatpickr-prev-month svg,
+body[data-bs-theme="dark"] .flatpickr-months .flatpickr-next-month svg {
+    fill: #dce1e7;
+}
+body[data-bs-theme="dark"] .flatpickr-months .flatpickr-prev-month:hover svg,
+body[data-bs-theme="dark"] .flatpickr-months .flatpickr-next-month:hover svg {
+    fill: #fff;
+}
+body[data-bs-theme="dark"] span.flatpickr-weekday {
+    color: #8899aa;
+}
+body[data-bs-theme="dark"] .flatpickr-current-month .numInputWrapper .cur-year {
+    color: #dce1e7;
+    background-color: transparent;
+}
+body[data-bs-theme="dark"] .flatpickr-current-month .flatpickr-monthDropdown-months option {
+    background-color: #1a2332;
+    color: #dce1e7;
+}
+body[data-bs-theme="dark"] .flatpickr-day {
+    color: #dce1e7;
+}
+body[data-bs-theme="dark"] .flatpickr-day:hover,
+body[data-bs-theme="dark"] .flatpickr-day:focus {
+    background-color: #25384f;
+    border-color: #25384f;
+    color: #fff;
+}
+body[data-bs-theme="dark"] .flatpickr-day.today {
+    border-color: #3b82f6;
+    color: #3b82f6;
+}
+body[data-bs-theme="dark"] .flatpickr-day.today:hover {
+    background-color: #3b82f6;
+    color: #fff;
+}
+body[data-bs-theme="dark"] .flatpickr-day.selected,
+body[data-bs-theme="dark"] .flatpickr-day.selected:hover {
+    background-color: #3b82f6;
+    border-color: #3b82f6;
+    color: #fff;
+}
+body[data-bs-theme="dark"] .flatpickr-day.prevMonthDay,
+body[data-bs-theme="dark"] .flatpickr-day.nextMonthDay {
+    color: #4a5568;
+}
+body[data-bs-theme="dark"] .flatpickr-day.prevMonthDay:hover,
+body[data-bs-theme="dark"] .flatpickr-day.nextMonthDay:hover {
+    background-color: #25384f;
+    border-color: #25384f;
+    color: #8899aa;
+}
+body[data-bs-theme="dark"] .flatpickr-time {
+    border-top-color: #25384f;
+}
+body[data-bs-theme="dark"] .flatpickr-time input,
+body[data-bs-theme="dark"] .flatpickr-time .flatpickr-time-separator,
+body[data-bs-theme="dark"] .flatpickr-time .flatpickr-am-pm {
+    color: #dce1e7;
+}
+body[data-bs-theme="dark"] .flatpickr-time input:hover,
+body[data-bs-theme="dark"] .flatpickr-time input:focus {
+    background-color: #25384f;
+}
+body[data-bs-theme="dark"] .flatpickr-time .numInputWrapper span.arrowUp::after {
+    border-bottom-color: #dce1e7;
+}
+body[data-bs-theme="dark"] .flatpickr-time .numInputWrapper span.arrowDown::after {
+    border-top-color: #dce1e7;
+}
+body[data-bs-theme="dark"] .flatpickr-months .numInputWrapper span.arrowUp::after {
+    border-bottom-color: #dce1e7;
+}
+body[data-bs-theme="dark"] .flatpickr-months .numInputWrapper span.arrowDown::after {
+    border-top-color: #dce1e7;
+}

--- a/starlette_admin/statics/js/dark-mode.js
+++ b/starlette_admin/statics/js/dark-mode.js
@@ -1,0 +1,22 @@
+/*
+ * Automatic dark mode.
+ *
+ * Follows the operating system / browser color-scheme preference and reflects
+ * it on the <body> via Tabler's `data-bs-theme="dark"` attribute. The attribute
+ * is kept in sync when the user changes their system preference at runtime.
+ */
+(function () {
+    function applyTheme() {
+        const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (prefersDarkScheme) {
+            document.body.setAttribute("data-bs-theme", "dark");
+        } else {
+            document.body.removeAttribute("data-bs-theme");
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        applyTheme();
+        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", applyTheme);
+    });
+})();

--- a/starlette_admin/templates/base.html
+++ b/starlette_admin/templates/base.html
@@ -11,6 +11,7 @@
     {% block title %}<title>{{ title or app_title }}</title>{% endblock %}
     <link rel="stylesheet" href="{{ url_for(__name__ ~ ':statics', path='css/tabler.min-1.1.0.css') }}">
     <link rel="stylesheet" href="{{ url_for(__name__ ~ ':statics', path='css/fontawesome.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for(__name__ ~ ':statics', path='css/dark-mode.css') }}">
     <style>
         @import url('https://rsms.me/inter/inter.css');
 
@@ -37,6 +38,7 @@
 <script type="text/javascript" src="{{ url_for(__name__ ~ ':statics', path='js/vendor/js.cookie.min.js') }}"></script>
 <script type="text/javascript"
         src="{{ url_for(__name__ ~ ':statics', path='js/vendor/tabler.min-1.1.0.js') }}"></script>
+<script type="text/javascript" src="{{ url_for(__name__ ~ ':statics', path='js/dark-mode.js') }}"></script>
 {% block script %}{% endblock %}
 <script>
     $(function () {


### PR DESCRIPTION
## Related
- Closes issue #378
- Replaces #733 (Unintentionally overwrote the brunch a while ago)

## Summary

This PR adds automatic **dark mode** support to the starlette-admin interface. The admin now follows the user's operating system / browser color-scheme preference and switches between light and dark themes accordingly — with no configuration required.

Tabler (the underlying UI framework) already ships a dark theme that is enabled via the `data-bs-theme="dark"` attribute on `<body>`. This PR wires that up automatically and patches the bundled third-party widgets that don't ship their own dark variants.

## What's included

- **`starlette_admin/statics/js/dark-mode.js`** — Detects the `prefers-color-scheme: dark` media query and toggles `data-bs-theme="dark"` on `<body>`. It applies the theme on page load and keeps it in sync if the user changes their system preference at runtime.
- **`starlette_admin/statics/css/dark-mode.css`** — Dark-mode styling fixes for the bundled widgets that don't provide dark variants out of the box:
  - **Select2** dropdowns, single/multiple selections and search fields
  - **DataTables** button collections and popovers
  - **Flatpickr** date/time picker (calendar, month/weekday headers, day cells, time inputs and navigation arrows)
- **`starlette_admin/templates/base.html`** — Includes the new stylesheet and script in the base template.

## Behavior

- **Automatic**: follows the OS/browser theme preference; no toggle or setting needed.
- **Reactive**: responds to live changes in the system color scheme.
- **Consistent**: bundled widgets (Select2, DataTables, Flatpickr) are restyled to match the dark theme.
- **Non-breaking**: light mode remains the default when the system preference is light; no public API changes.

## Files changed

| File | Change |
| --- | --- |
| `starlette_admin/statics/css/dark-mode.css` | New file (126 lines) |
| `starlette_admin/statics/js/dark-mode.js` | New file (22 lines) |
| `starlette_admin/templates/base.html` | +2 lines (include CSS & JS) |

## How to test

1. Run any of the bundled examples (e.g. `examples/sqla`).
2. Set your operating system or browser to **dark** appearance.
3. Open the admin — the UI should render in dark mode.
4. Toggle your system theme back to **light** and confirm the admin switches without a page reload.
5. Verify the Select2 dropdowns, DataTables column-visibility buttons and Flatpickr date pickers are legible in dark mode.

