### PR TITLE
Allow filtering on enum ListField

### DIFF
--- a/starlette_admin/statics/js/list.js
+++ b/starlette_admin/statics/js/list.js
@@ -29,7 +29,7 @@ $(function () {
           .concat(fringe);
       else if (field.type === "ListField") {
         // To reduce complexity, List of CollectionField will render as json
-        if (field.field.type == "CollectionField") {
+        if (field.field.type === "CollectionField" || field.field.type === "EnumField") {
           $("#table-header").append(`<th>${field.label}</th>`);
           dt_columns.push({
             name: field.name,
@@ -46,6 +46,9 @@ $(function () {
               );
             },
           });
+          if (field.field.type === "EnumField") {
+            dt_fields.push(field);
+          }
         } else {
           field.field.name = field.name;
           field.field.label = field.label;
@@ -180,38 +183,67 @@ $(function () {
     };
   };
 
+  enumInit = function (a, fn, preDefined = null, field = null) {
+      if (field == null) {
+        field = dt_fields.find((f) => f.name === a.s.origData);
+      }
+
+      const choices = Array.isArray(field?.choices) ? field.choices : [];
+
+      const select = $("<select/>")
+        .addClass(a.classes.input)
+        .addClass(a.classes.value)
+        .addClass(a.classes.dropDown)
+        .addClass(a.classes.select)
+        .append(a.dom.valueTitle)
+        .on("change.dtsb", function () {
+          fn(a, this);
+        });
+
+      choices.forEach((choice) => {
+        const option = $("<option>", {
+          text: choice[1],
+          value: choice[0],
+        });
+        select.append(option);
+      });
+
+      if (preDefined !== null && choices.some(choice => choice[0] == preDefined[0])) {
+        select.val(preDefined[0]);
+      }
+
+      return select;
+    }
+
   enumCondition = function (cn) {
+    return {
+      conditionName: function (t, i) {
+        return t.i18n(cn);
+      },
+      init: enumInit,
+      inputValue: function (el, that) {
+        return [$(el[0]).val()];
+      },
+      isInputValid: function (el, that) {
+        return ($(el[0]).val() ?? "") !== "";
+      },
+    };
+  };
+
+  enumArrayCondition = function (cn) {
     return {
       conditionName: function (t, i) {
         return t.i18n(cn);
       },
       init: function (a, fn, preDefined = null) {
         const field = dt_fields.find((f) => f.name === a.s.origData);
-        const choices = Array.isArray(field?.choices) ? field.choices : [];
 
-        const select = $("<select/>")
-          .addClass(a.classes.input)
-          .addClass(a.classes.value)
-          .addClass(a.classes.dropDown)
-          .addClass(a.classes.select)
-          .append(a.dom.valueTitle)
-          .on("change.dtsb", function () {
-            fn(a, this);
-          });
-
-        choices.forEach((choice) => {
-          const option = $("<option>", {
-            text: choice[1],
-            value: choice[0],
-          });
-          select.append(option);
-        });
-
-        if (preDefined !== null && choices.some(choice => choice[0] == preDefined[0])) {
-          select.val(preDefined[0]);
+        if (field.field.type === "EnumField") {
+          return enumInit(a, fn, preDefined, field.field);
         }
-
-        return select;
+        else {
+          return DataTable.Criteria.initSelectArray(a, fn, preDefined, field);
+        }
       },
       inputValue: function (el, that) {
         return [$(el[0]).val()];
@@ -252,6 +284,10 @@ $(function () {
             null: noInputCondition("starlette-admin.conditions.empty"),
             "!null": noInputCondition("starlette-admin.conditions.notEmpty"),
           },
+          array: {
+            contains: enumArrayCondition("searchBuilder.conditions.array.contains"),
+            without: enumArrayCondition("searchBuilder.conditions.array.without"),
+          }
         },
         greyscale: true,
       },

--- a/starlette_admin/statics/js/list.js
+++ b/starlette_admin/statics/js/list.js
@@ -29,6 +29,7 @@ $(function () {
           .concat(fringe);
       else if (field.type === "ListField") {
         // To reduce complexity, List of CollectionField will render as json
+        // List of EnumField preserves array, allowing multiple selections
         if (field.field.type === "CollectionField" || field.field.type === "EnumField") {
           $("#table-header").append(`<th>${field.label}</th>`);
           dt_columns.push({
@@ -237,13 +238,7 @@ $(function () {
       },
       init: function (a, fn, preDefined = null) {
         const field = dt_fields.find((f) => f.name === a.s.origData);
-
-        if (field.field.type === "EnumField") {
-          return enumInit(a, fn, preDefined, field.field);
-        }
-        else {
-          return DataTable.Criteria.initSelectArray(a, fn, preDefined, field);
-        }
+        return enumInit(a, fn, preDefined, field.field);
       },
       inputValue: function (el, that) {
         return [$(el[0]).val()];

--- a/starlette_admin/templates/list.html
+++ b/starlette_admin/templates/list.html
@@ -158,5 +158,5 @@
     <script type="text/javascript"
             src="{{ url_for(__name__ ~ ':statics', path='js/actions.js').include_query_params(v=1) }}"></script>
     <script type="text/javascript"
-            src="{{ url_for(__name__ ~ ':statics', path='js/list.js').include_query_params(v=3) }}"></script>
+            src="{{ url_for(__name__ ~ ':statics', path='js/list.js').include_query_params(v=4) }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Related
– Builds on: https://github.com/jowilf/starlette-admin/pull/746

## Summary
This PR adapts the multiple choice behaviour of `EnumField` by testing with `contains`, so that combinations of options from the enum are available for filtering.

## Changes
### New Features
* Use datatables array operators `contains` and `without` to allow filtering of enum-type `ListField` columns.

### Modified Files
* `starlette_admin/statics/js/list.js` — Use the encapsulated `EnumField` within the `ListField`. Add new `enumArrayCondition` and share code between this and extant `enumCondition`.
* `starlette_admin/templates/list.html` — Bump `v=3` to `v=4` for `js/list.js` src path.

### Usage
Filter an enum `ListField` using the array operators `contains` and `without`.

<img width="487" height="187" alt="image" src="https://github.com/user-attachments/assets/0908f04c-47a5-43ca-8309-069ac31fbfb0" />

### Testing
Manual verification of `ListField`, `EnumField` and enum `ListField`.
