### PR TITLE
Validate next redirect target is same-origin

### DIFF
--- a/starlette_admin/auth.py
+++ b/starlette_admin/auth.py
@@ -1,7 +1,7 @@
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Union, cast
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -14,12 +14,22 @@ from starlette_admin.i18n import lazy_gettext as _
 if TYPE_CHECKING:
     from starlette_admin.base import BaseAdmin
 
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
 from starlette.types import ASGIApp
+
+
+def _is_safe_redirect_url(request: Request, url: Optional[str]) -> bool:
+    """Only allow relative paths or absolute URLs on the same origin as the request."""
+    if not url or "\\" in url:
+        return False
+    parsed = urlparse(url)
+    if not parsed.scheme and not parsed.netloc:
+        return True
+    return parsed.scheme == request.url.scheme and parsed.netloc == request.url.netloc
 
 
 def login_not_required(
@@ -232,6 +242,9 @@ class AuthProvider(BaseAuthProvider):
                 context={"_is_login_path": True},
             )
         form = await request.form()
+        next_url = request.query_params.get("next")
+        if not _is_safe_redirect_url(request, next_url):
+            next_url = str(request.url_for(admin.route_name + ":index"))
         try:
             return await self.login(
                 form.get("username"),  # type: ignore
@@ -239,8 +252,7 @@ class AuthProvider(BaseAuthProvider):
                 form.get("remember_me") == "on",
                 request,
                 RedirectResponse(
-                    request.query_params.get("next")
-                    or request.url_for(admin.route_name + ":index"),
+                    cast(str, next_url),
                     status_code=HTTP_303_SEE_OTHER,
                 ),
             )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -191,6 +191,64 @@ class TestAuth:
         assert response.status_code == 303
         assert "session" not in response.cookies
 
+    @pytest.mark.asyncio
+    async def test_login_redirects_back_to_same_origin_next(self):
+        admin = BaseAdmin(auth_provider=MyAuthProvider())
+        app = Starlette()
+        admin.mount_to(app)
+        client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        )
+        # Unauthenticated request to a protected route: the middleware builds
+        # an absolute-URL `next` from the original request (including query
+        # string), which must survive the login round trip unchanged.
+        response = await client.get("/admin/?foo=bar", follow_redirects=False)
+        assert response.status_code == 303
+        login_location = response.headers.get("location")
+        assert (
+            login_location
+            == "http://testserver/admin/login?next=http%3A%2F%2Ftestserver%2Fadmin%2F%3Ffoo%3Dbar"
+        )
+        response = await client.post(
+            login_location,
+            data={"username": "admin", "password": "password", "remember_me": "on"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        assert response.headers.get("location") == "http://testserver/admin/?foo=bar"
+
+    @pytest.mark.asyncio
+    async def test_login_redirects_to_relative_next(self):
+        admin = BaseAdmin(auth_provider=MyAuthProvider())
+        app = Starlette()
+        admin.mount_to(app)
+        client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        )
+        response = await client.post(
+            "/admin/login?next=/admin/post/list",
+            data={"username": "admin", "password": "password", "remember_me": "on"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        assert response.headers.get("location") == "/admin/post/list"
+
+    @pytest.mark.asyncio
+    async def test_login_rejects_open_redirect(self):
+        admin = BaseAdmin(auth_provider=MyAuthProvider())
+        app = Starlette()
+        admin.mount_to(app)
+        client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        )
+        response = await client.post(
+            "/admin/login?next=https://evil.com",
+            data={"username": "admin", "password": "password", "remember_me": "on"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        assert response.headers.get("location") == "http://testserver/admin/"
+
 
 class TestViewAccess:
     def setup_method(self, method):


### PR DESCRIPTION
Adds a same-origin check on the `next` query param used for post-login redirects, falling back to the admin index if it's off-origin.

Tests: confirms the legitimate deep-link → login → return flow still works, and confirms off-origin values are rejected.

No API changes. All existing tests pass (102 passed, 2 pre-existing unrelated skips).