### PR TITLE
Fix language switcher links for sub-path deployments

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
           enable-cache: true
       - name: Install Dependencies
         run: uv sync --only-group docs --only-group dev
-      - run: uv run poe docs-build-all
+      - run: uv run poe docs-build-prod
       - uses: actions/upload-pages-artifact@v5
         with:
           path: site

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,6 +270,13 @@ uv run poe docs-serve
 
 and visit http://localhost:8080 in your browser to see a live preview of your documentation.
 
+To preview the site exactly as it is deployed (with the language switcher
+links and URLs under the `/starlette-admin` base path), run:
+
+```shell
+uv run poe docs-serve-prod
+```
+
 ## Attribution
 
 This guide is based on the **contributing.md**. [Make your own](https://contributing.md/)!

--- a/docs/scripts/build.py
+++ b/docs/scripts/build.py
@@ -13,9 +13,11 @@ from i18n import (
     SHARED_DIR,
     SHARED_ITEMS,
     I18nError,
+    generate_english_config,
     generate_locale_config,
     iter_markdown,
     locale_content_dir,
+    normalize_prefix,
     resolve_locales,
     staleness_pass,
     sync_alternates,
@@ -61,6 +63,13 @@ def main() -> int:
         metavar="LOC",
         help="locale codes to build after English ('all' for every supported locale)",
     )
+    parser.add_argument(
+        "--alternate-prefix",
+        default="/",
+        metavar="PATH",
+        help="deployment base path mirrored in the language switcher links "
+        '(default: "/"; e.g. "/starlette-admin" for GitHub Pages project sites)',
+    )
     args, extras = parser.parse_known_args()
 
     try:
@@ -70,7 +79,11 @@ def main() -> int:
         return 1
 
     sync_all_shared()
-    code = run_zensical(extras)
+    if normalize_prefix(args.alternate_prefix):
+        english_config = generate_english_config(args.alternate_prefix)
+        code = run_zensical(["--config-file", str(english_config), *extras])
+    else:
+        code = run_zensical(extras)
     if code != 0 or not args.locales:
         return code
 
@@ -88,7 +101,7 @@ def main() -> int:
         flipped = staleness_pass(content)
         if flipped:
             print(f"staleness pass ({loc}): {flipped} notice(s) updated", flush=True)
-        config_path = generate_locale_config(loc)
+        config_path = generate_locale_config(loc, args.alternate_prefix)
         print(f"building locale '{loc}' with {config_path.name}", flush=True)
         code = run_zensical(["--config-file", str(config_path), *extras])
         if code != 0:

--- a/docs/scripts/i18n.py
+++ b/docs/scripts/i18n.py
@@ -568,11 +568,15 @@ def _nav_translation_stats(
     return translated, expected
 
 
-def generate_locale_config(code: str) -> Path:
+def generate_locale_config(code: str, prefix: str = "/") -> Path:
     validate_nav(code)
     config = tomllib.loads(ROOT_CONFIG_PATH.read_text(encoding="utf-8"))["project"]
     config["docs_dir"] = f"docs/locales/{code}/{CONTENT_SUBDIR}"
     config["site_dir"] = f"site/{code}"
+    # Absolute URL of this locale (canonical tags, sitemap); `site_url`
+    # already carries the deployment base path.
+    config["site_url"] = f"{site_url()}{code}"
+    config.setdefault("extra", {})["alternate"] = alternate_entries(prefix)
     theme = config.setdefault("theme", {})
     theme["language"] = code
     nav_data = load_nav_json(code)
@@ -593,6 +597,19 @@ def generate_locale_config(code: str) -> Path:
     return out_path
 
 
+def generate_english_config(prefix: str) -> Path:
+    """Root config copy whose switcher links use the given base path.
+
+    Used for builds with a non-default `--alternate-prefix` so the tracked
+    root config always keeps its default "/" entries.
+    """
+    config = tomllib.loads(ROOT_CONFIG_PATH.read_text(encoding="utf-8"))["project"]
+    config.setdefault("extra", {})["alternate"] = alternate_entries(prefix)
+    out_path = PROJECT_ROOT / f"zensical.{SOURCE_LOCALE}.toml"
+    out_path.write_text(dump_toml(config), encoding="utf-8")
+    return out_path
+
+
 # --------------------------------------------------------------------------
 # Language switcher (`extra.alternate`) in the main zensical.toml
 # --------------------------------------------------------------------------
@@ -603,21 +620,37 @@ ALTERNATE_MARKER = (
 )
 
 
-def alternate_entries() -> list[dict[str, str]]:
-    """Language switcher entries: English at the site root, locales in subdirs."""
+def alternate_entries(prefix: str = "/") -> list[dict[str, str]]:
+    """Language switcher entries: English at the site root, locales in subdirs.
+
+    Links are root-relative and must mirror the deployment base path
+    (`prefix`, e.g. "/starlette-admin" for GitHub Pages project sites)
+    because zensical renders them verbatim on every page.
+    """
+    base = normalize_prefix(prefix)
     entries = [
-        {"name": f"{SOURCE_LOCALE} - English", "link": "/", "lang": SOURCE_LOCALE}
+        {
+            "name": f"{SOURCE_LOCALE} - English",
+            "link": f"{base}/" if base else "/",
+            "lang": SOURCE_LOCALE,
+        }
     ]
     for entry in load_registry():
         code = entry["code"]
         entries.append(
             {
                 "name": f"{code} - {entry.get('name') or code}",
-                "link": f"/{code}/",
+                "link": f"{base}/{code}/",
                 "lang": code,
             }
         )
     return entries
+
+
+def normalize_prefix(prefix: str) -> str:
+    """Normalize a base path to "" or "/starlette-admin" form."""
+    stripped = prefix.strip().strip("/")
+    return f"/{stripped}" if stripped else ""
 
 
 def render_alternate_block() -> str:

--- a/docs/scripts/serve.py
+++ b/docs/scripts/serve.py
@@ -1,4 +1,9 @@
-"""Serve the built site folder, rebuilding on changes."""
+"""Serve the built site folder, rebuilding on changes.
+
+With `--alternate-prefix`, the site is served under the same base path as
+the deployment (e.g. /starlette-admin), so root-relative language switcher
+links behave exactly like in production; unprefixed URLs are redirected.
+"""
 
 import argparse
 import contextlib
@@ -9,6 +14,11 @@ import sys
 import threading
 import time
 from pathlib import Path
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from i18n import normalize_prefix
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 DOCS_DIR = PROJECT_ROOT / "docs"
@@ -37,8 +47,8 @@ def snapshot() -> dict[str, float]:
     return state
 
 
-def build(locales: list[str] | None = None) -> None:
-    command = [sys.executable, str(BUILD_SCRIPT)]
+def build(locales: list[str] | None = None, prefix: str = "/") -> None:
+    command = [sys.executable, str(BUILD_SCRIPT), "--alternate-prefix", prefix]
     if locales:
         command.extend(["--locales", *locales])
     result = subprocess.run(command, cwd=PROJECT_ROOT, check=False)
@@ -47,7 +57,8 @@ def build(locales: list[str] | None = None) -> None:
 
 
 class Handler(http.server.SimpleHTTPRequestHandler):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, prefix: str = "", **kwargs):
+        self.prefix = prefix
         super().__init__(*args, directory=str(SITE_DIR), **kwargs)
 
     def log_message(self, format: str, *args) -> None:
@@ -56,6 +67,42 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     def handle(self) -> None:
         with contextlib.suppress(BrokenPipeError, ConnectionResetError):
             super().handle()
+
+    def _redirect(self, location: str) -> None:
+        self.send_response(301)
+        self.send_header("Location", location)
+        self.end_headers()
+
+    def _unprefixed_location(self) -> str | None:
+        """Location to redirect to when the URL lacks the prefix, else None."""
+        if not self.prefix:
+            return None
+        target = urlparse(self.path).path
+        if target == self.prefix or target.startswith(f"{self.prefix}/"):
+            return None
+        return f"{self.prefix}{self.path}"
+
+    def do_GET(self) -> None:
+        location = self._unprefixed_location()
+        if location:
+            self._redirect(location)
+            return
+        super().do_GET()
+
+    def do_HEAD(self) -> None:
+        location = self._unprefixed_location()
+        if location:
+            self._redirect(location)
+            return
+        super().do_HEAD()
+
+    def translate_path(self, path: str) -> str:
+        clean = urlparse(path).path
+        if self.prefix and (
+            clean == self.prefix or clean.startswith(f"{self.prefix}/")
+        ):
+            clean = clean[len(self.prefix) :] or "/"
+        return super().translate_path(clean)
 
 
 def main() -> int:
@@ -72,14 +119,23 @@ def main() -> int:
         metavar="LOC",
         help="locale codes to build on each rebuild ('all' for every supported locale)",
     )
+    parser.add_argument(
+        "--alternate-prefix",
+        default="/",
+        metavar="PATH",
+        help="serve the site under this base path and build matching "
+        'language switcher links (default: "/")',
+    )
     args = parser.parse_args()
+    prefix = normalize_prefix(args.alternate_prefix)
 
-    build(args.locales)
-    handler = functools.partial(Handler)
+    build(args.locales, prefix=args.alternate_prefix)
+    handler = functools.partial(Handler, prefix=prefix)
     server = http.server.ThreadingHTTPServer(("127.0.0.1", args.port), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    print(f"serving {SITE_DIR} at http://127.0.0.1:{args.port}", flush=True)
+    location = f"http://127.0.0.1:{args.port}{prefix}/"
+    print(f"serving {SITE_DIR} at {location}", flush=True)
 
     try:
         last = snapshot()
@@ -93,7 +149,7 @@ def main() -> int:
                     if current.get(k) != last.get(k)
                 }
                 print(f"change detected: {len(changed)} file(s), rebuilding...")
-                build(args.locales)
+                build(args.locales, prefix=args.alternate_prefix)
                 last = snapshot()  # Re-baseline: the build touches watched paths.
     except KeyboardInterrupt:
         print("\nstopping")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,8 @@ docs-serve = "python docs/scripts/serve.py"
 docs-build = "python docs/scripts/build.py"
 docs-serve-all = "python docs/scripts/serve.py --locales all"
 docs-build-all = "python docs/scripts/build.py --locales all"
+docs-serve-prod = "python docs/scripts/serve.py --locales all --alternate-prefix /starlette-admin"
+docs-build-prod = "python docs/scripts/build.py --locales all --alternate-prefix /starlette-admin"
 docs-translate = "python docs/scripts/translate.py"
 
 [tool.hatch.version]


### PR DESCRIPTION
## Summary
- Language switcher (`extra.alternate`) and head `rel=alternate` links were emitted as root-relative paths (e.g. `/fr/`), so on the GitHub Pages project site they resolved to `https://jowilf.github.io/fr/` (404) instead of `/starlette-admin/fr/`
- Locale builds reused the English `site_url`, so French pages shipped canonical tags / sitemap entries pointing at the English home page
